### PR TITLE
fix macos, use c instead of cpp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1"
 pkg-config = "0.3"

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,11 @@
-extern crate gcc;
+extern crate cc;
 extern crate pkg_config;
 
 use std::env;
 
 fn main() {
-	let mut build = gcc::Build::new();
-	build.cpp(true).file("webview-c/lib.cpp").include("webview-c");
+	let mut build = cc::Build::new();
+	build.file("webview-c/lib.c").include("webview-c");
 	if env::var("DEBUG").is_err() {
 		build.define("NDEBUG", None);
 	} else {
@@ -23,6 +23,10 @@ fn main() {
 		build.define("WEBVIEW_GTK", None);
 	} else if target.contains("apple") {
 		build.define("WEBVIEW_COCOA", None);
+		build.flag("-x");
+		build.flag("objective-c");
+		println!("cargo:rustc-link-lib=framework=Cocoa");
+		println!("cargo:rustc-link-lib=framework=WebKit");
 	} else {
 		panic!("unsupported target");
 	}

--- a/webview-c/lib.c
+++ b/webview-c/lib.c
@@ -1,7 +1,6 @@
 #define WEBVIEW_IMPLEMENTATION
 #include "webview.h"
 
-extern "C" {
 void wrapper_webview_free(struct webview* w) {
 	free(w);
 }
@@ -26,4 +25,4 @@ struct webview* wrapper_webview_new(const char* title, const char* url, int widt
 void* wrapper_webview_get_userdata(struct webview* w) {
 	return w->userdata;
 }
-}
+


### PR DESCRIPTION
This fixes macos compile. I'm not sure why you chose to use cpp instead of c, but since it uses no C++ features it seems redundant to use C++ to me. If you have bigger plans and want C++, you can just take the compile flags and commit those.

I switched to cc crate from gcc, because it was deprecated for cc.