### PR TITLE
Fix Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,22 @@ sudo: required
 language: rust
 cache: cargo
 
+os:
+  - linux
+  - osx
+
 rust:
   - stable
   - beta
   - nightly
 
 matrix:
-  include:
-    - os: linux
-      before_install:
-        - sudo add-apt-repository ppa:webkit-team/ppa -y
-        - sudo apt-get update
-        - sudo apt-get install libwebkit2gtk-4.0-dev -y
-    - os: osx
-      osx_image: xcode8.3
+  allow_failures:
+    - rust: nightly
+
+addons:
+  apt:
+    packages:
+      - libwebkit2gtk-4.0-dev
+    sources:
+      - sourceline: 'ppa:webkit-team/ppa'


### PR DESCRIPTION
Run builds on Linux and macOS against the stable, beta and nightly compilers, and don't let failing nightly compiler builds fail the overall build.

I've removed the osx_image key because xcode8.3 is the default value.

This is for #4. Hopefully it'll pass.