### PR TITLE
Link to appropriate Windows libraries.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,9 @@ fn main() {
 	let target = env::var("TARGET").unwrap();
 	if target.contains("windows") {
 		build.define("WEBVIEW_WINAPI", None);
+		for &lib in &["ole32", "comctl32", "oleaut32", "uuid"] {
+			println!("cargo:rustc-link-lib={}", lib);
+		}
 	} else if target.contains("linux") || target.contains("bsd") {
 		let webkit = pkg_config::Config::new().atleast_version("2.8").probe("webkit2gtk-4.0").unwrap();
 


### PR DESCRIPTION
Although I think this is necessary for it work for MinGW, it doesn't *seem* to break MSVC builds, either.

```sh
# Build command from the original README.
cc main.c -DWEBVIEW_WINAPI=1 -lole32 -lcomctl32 -loleaut32 -luuid -mwindows -o webview-example.exe
```

This might fix #12.