### PR TITLE
fix issue with ShowWindow on Windows (invisible window)

### DIFF
--- a/webview-c/webview.h
+++ b/webview-c/webview.h
@@ -1156,7 +1156,6 @@ static int webview_fix_ie_compat_mode() {
 WEBVIEW_API int webview_init(struct webview *w) {
   WNDCLASSEX wc;
   HINSTANCE hInstance;
-  STARTUPINFO info;
   DWORD style;
   RECT clientRect;
   RECT rect;
@@ -1169,7 +1168,6 @@ WEBVIEW_API int webview_init(struct webview *w) {
   if (hInstance == NULL) {
     return -1;
   }
-  GetStartupInfo(&info);
   if (OleInitialize(NULL) != S_OK) {
     return -1;
   }
@@ -1213,7 +1211,7 @@ WEBVIEW_API int webview_init(struct webview *w) {
   DisplayHTMLPage(w);
 
   SetWindowText(w->priv.hwnd, w->title);
-  ShowWindow(w->priv.hwnd, info.wShowWindow);
+  ShowWindow(w->priv.hwnd, SW_SHOWDEFAULT);
   UpdateWindow(w->priv.hwnd);
   SetFocus(w->priv.hwnd);
 


### PR DESCRIPTION
**issue**: window is not visible when app is started from VSCode powershell terminal.

**cause**: `STARTUP_INFO.wShowWindow` were used without checking for `STARTF_USESHOWWINDOW` flag.

**fix**: use `ShowWindow(..., SW_SHOWDEFAULT)` - it will apply correct value from `STARTUP_INFO` on it's own.