### PR TITLE
Implement file dialogs (and update webview-c)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["examples/todo-ps/dist/**/*"]
 
 [dependencies]
 fnv = "1.0"
+bitflags = "1"
 
 [dev-dependencies]
 urlencoding = "1.0"

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -5,6 +5,30 @@ pub enum CWebView {} // opaque type, only used in ffi pointers
 type ErasedExternalInvokeFn = extern "system" fn(webview: *mut CWebView, arg: *const c_char);
 type ErasedDispatchFn = extern "system" fn(webview: *mut CWebView, arg: *mut c_void);
 
+#[repr(C)]
+pub enum DialogType {
+	Open  = 0,
+	Save  = 1,
+	Alert = 2,
+}
+
+bitflags! {
+#[repr(C)]
+pub struct DialogFlags: u32 {
+	#[allow(non_upper_case_globals)]
+	const File      = 0b0000;
+	#[allow(non_upper_case_globals)]
+	const Directory = 0b0001;
+	#[allow(non_upper_case_globals)]
+	const Info      = 0b0010;
+	#[allow(non_upper_case_globals)]
+	const Warning   = 0b0100;
+	#[allow(non_upper_case_globals)]
+	const Error     = 0b0110;
+	#[allow(non_upper_case_globals)]
+	const AlertMask = 0b0110;
+}}
+
 extern {
 	pub fn wrapper_webview_free(this: *mut CWebView);
 	pub fn wrapper_webview_new(title: *const c_char, url: *const c_char, width: c_int, height: c_int, resizable: c_int, debug: c_int, external_invoke_cb: Option<ErasedExternalInvokeFn>, userdata: *mut c_void) -> *mut CWebView;
@@ -16,4 +40,5 @@ extern {
 	pub fn webview_eval(this: *mut CWebView, js: *const c_char) -> c_int;
 	pub fn webview_inject_css(this: *mut CWebView, css: *const c_char) -> c_int;
 	pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
+	pub fn webview_dialog(this: *mut CWebView, dialog_type: DialogType, dialog_flags: DialogFlags, title: *const c_char, arg: *const c_char, result: *mut c_char, result_size: usize);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod ffi;
 
 use std::os::raw::*;
 use std::ffi::{CString, CStr};
-use std::mem::transmute;
+use std::mem::{transmute, forget};
 use std::marker::PhantomData;
 use std::ptr;
 
@@ -116,13 +116,14 @@ impl<'a, T> WebView<'a, T> {
 	pub fn dialog(&mut self, dtype: DialogType, dflags: DialogFlags, title: &str, arg: Option<&str>) -> String {
 		let title = CString::new(title).unwrap();
 		let arg = arg.map(|a| CString::new(a).unwrap());
-		let result_size = 4096; // I don't know why you'd ever have so long paths, maybe you're encoding data in it?
-		let mut result  = Vec::with_capacity(result_size);
-		result.push(0); // If cancel is pressed nothing is written to the buffer.
-		let result = result.as_mut_ptr();
-		unsafe { webview_dialog(self.erase(), dtype, dflags, title.as_ptr(), arg.map_or(ptr::null(), |a| a.as_ptr()), result, result_size) };
+		let buffer_size = 4096; // I don't know why you'd ever have so long paths, maybe you're encoding data in it?
+		let mut buffer  = Vec::with_capacity(buffer_size);
+		buffer.push(0); // If cancel is pressed nothing is written to the buffer.
+		let result = buffer.as_mut_ptr();
+		forget(buffer);
+		unsafe { webview_dialog(self.erase(), dtype, dflags, title.as_ptr(), arg.map_or(ptr::null(), |a| a.as_ptr()), result, buffer_size) };
 
-		let mut result = unsafe { Vec::from_raw_parts(result, result_size, result_size) };
+		let mut result = unsafe { Vec::from_raw_parts(result, buffer_size, buffer_size) };
 		let len = result.iter().position(|&c| c == 0).unwrap(); // if we don't find a null byte something has gone wrong anyways ¯\_(ツ)_/¯
 		result.truncate(len);
 		result.shrink_to_fit(); // the space allocated is probably an order of a magnitude larger than the path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,9 @@ impl<'a, T> WebView<'a, T> {
 		let title = CString::new(title).unwrap();
 		let arg = arg.map(|a| CString::new(a).unwrap());
 		let result_size = 4096; // I don't know why you'd ever have so long paths, maybe you're encoding data in it?
-		let result      = Vec::with_capacity(result_size).as_mut_ptr();
+		let mut result  = Vec::with_capacity(result_size);
+		result.push(0); // If cancel is pressed nothing is written to the buffer.
+		let result = result.as_mut_ptr();
 		unsafe { webview_dialog(self.erase(), dtype, dflags, title.as_ptr(), arg.map_or(ptr::null(), |a| a.as_ptr()), result, result_size) };
 
 		let mut result = unsafe { Vec::from_raw_parts(result, result_size, result_size) };

--- a/webview-c/lib.c
+++ b/webview-c/lib.c
@@ -7,14 +7,14 @@ void wrapper_webview_free(struct webview* w) {
 
 struct webview* wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 	struct webview* w = (struct webview*)calloc(1, sizeof(*w));
-	w->width = width;
-	w->height = height;
-	w->title = title;
-	w->url = url;
-	w->resizable = resizable;
-	w->debug = debug;
+	w->width              = width;
+	w->height             = height;
+	w->title              = title;
+	w->url                = url;
+	w->resizable          = resizable;
+	w->debug              = debug;
 	w->external_invoke_cb = external_invoke_cb;
-	w->userdata = userdata;
+	w->userdata           = userdata;
 	if (webview_init(w) != 0) {
 		wrapper_webview_free(w);
 		return NULL;


### PR DESCRIPTION
This PR implements rust bindings for the file dialogs in webview.

This PR also introduces another dependency `bitflags` for the DialogFlags type. Please tell me if this is not acceptable.

I don't know how well file dialogs work in older versions of webview, so I also updated the version. It seems to work fine for me.