### PR TITLE
Add support for webview_set_color and use it in todo example.

### DIFF
--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -32,7 +32,9 @@ fn main() {
 	let size = (320, 480);
 	let resizable = false;
 	let debug = true;
-	let init_cb = |_webview| {};
+	let init_cb = |webview: MyUnique<WebView<Vec<Task>>>| {
+		webview.dispatch(|wv, _| wv.set_color(156, 39, 176, 255));
+	};
 	let userdata = vec![];
 	let (tasks, _) = run("Rust Todo App", Content::Html(html), Some(size), resizable, debug, init_cb, |webview, arg, tasks: &mut Vec<Task>| {
 		use Cmd::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,10 @@ impl<'a, T> WebView<'a, T> {
 		unsafe { webview_inject_css(self.erase(), css.as_ptr()) }
 	}
 
+	pub fn set_color(&mut self, red: u8, green: u8, blue: u8, alpha: u8) {
+		unsafe { webview_set_color(self.erase(), red, green, blue, alpha) }
+	}
+
 	pub fn dialog(&mut self, dialog: Dialog, title: &str, arg: &str) -> String {
 		let (dtype, dflags) = dialog.parameters();
 		let mut s = [0u8; 4096];

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -37,5 +37,6 @@ extern {
 	pub fn webview_eval(this: *mut CWebView, js: *const c_char) -> c_int;
 	pub fn webview_inject_css(this: *mut CWebView, css: *const c_char) -> c_int;
 	pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
+	pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 	pub fn webview_dialog(this: *mut CWebView, dialog_type: DialogType, flags: DialogFlags, title: *const c_char, arg: *const c_char, result: *mut c_char, result_size: usize);
 }


### PR DESCRIPTION
This adds support for `webview_set_color` added in zserge/webview#73 which allows you to set the window's background color.