### PR TITLE
Add support for webview_set_title and use it in todo example.

### DIFF
--- a/examples/todo.rs
+++ b/examples/todo.rs
@@ -43,6 +43,7 @@ fn main() {
 			markTask { index, done } => tasks[index].done = done,
 			clearDoneTasks => tasks.retain(|t| !t.done),
 		}
+		webview.set_title(&format!("Rust Todo App ({} Tasks)", tasks.len()));
 		render(webview, tasks);
 	}, userdata);
 	println!("final state: {:?}", tasks);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,11 @@ impl<'a, T> WebView<'a, T> {
 		unsafe { webview_inject_css(self.erase(), css.as_ptr()) }
 	}
 
+	pub fn set_title(&mut self, title: &str) {
+		let title = CString::new(title).unwrap();
+		unsafe { webview_set_title(self.erase(), title.as_ptr()) }
+	}
+
 	pub fn dialog(&mut self, dialog: Dialog, title: &str, arg: &str) -> String {
 		let (dtype, dflags) = dialog.parameters();
 		let mut s = [0u8; 4096];

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -36,6 +36,7 @@ extern {
 	pub fn webview_dispatch(this: *mut CWebView, f: Option<ErasedDispatchFn>, arg: *mut c_void);
 	pub fn webview_eval(this: *mut CWebView, js: *const c_char) -> c_int;
 	pub fn webview_inject_css(this: *mut CWebView, css: *const c_char) -> c_int;
+	pub fn webview_set_title(this: *mut CWebView, title: *const c_char);
 	pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
 	pub fn webview_dialog(this: *mut CWebView, dialog_type: DialogType, flags: DialogFlags, title: *const c_char, arg: *const c_char, result: *mut c_char, result_size: usize);
 }


### PR DESCRIPTION
This adds support for changing the title of the webview after its creation. The use in the todo example now incorporates the number of tasks into the title.