### PR TITLE
Fix memory leak

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,15 @@ impl<'a, T> WebView<'a, T> {
     }
 
     /// Consumes the `WebView` and returns ownership of the user data.
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(mut self) -> T {
+        unsafe {
+            let user_data = self._into_inner();
+            mem::forget(self);
+            user_data
+        }
+    }
+
+    unsafe fn _into_inner(&mut self) -> T {
         let _lock = self
             .user_data_wrapper()
             .live
@@ -487,7 +495,9 @@ impl<'a, T> WebView<'a, T> {
             .expect("A dispatch channel thread panicked while holding mutex to WebView.");
 
         let user_data_ptr = self.user_data_wrapper_ptr();
-        let user_data = unsafe { *Box::from_raw(user_data_ptr) };
+        webview_exit(self.inner);
+        wrapper_webview_free(self.inner);
+        let user_data = *Box::from_raw(user_data_ptr);
         user_data.inner
     }
 }
@@ -495,8 +505,7 @@ impl<'a, T> WebView<'a, T> {
 impl<'a, T> Drop for WebView<'a, T> {
     fn drop(&mut self) {
         unsafe {
-            webview_exit(self.inner);
-            wrapper_webview_free(self.inner);
+            self._into_inner();
         }
     }
 }


### PR DESCRIPTION
https://github.com/Boscop/web-view/commit/8bcb16f52fc7c4724fc8bbf66a85dea253a36f40 fixed a double free, but because `drop` no longer calls `Box::from_raw`, the userdata will be leaked if the WebView is dropped without calling `run` or `into_inner`. This reverts https://github.com/Boscop/web-view/commit/8bcb16f52fc7c4724fc8bbf66a85dea253a36f40 but prevents the double free by calling `mem::forget` on the WebView before returning the userdata.