### PR TITLE
Add ability to override webview source with WEBVIEW_DIR environment variable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 //! It uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and MSHTML (IE10/11) on Windows, so your app
 //! will be **much** leaner than with Electron.
 //!
+//! To use a custom version of webview, define an environment variable WEBVIEW_DIR with the path to
+//! its source directory.
+//!
 //! For usage info please check out [the examples] and the [original readme].
 //!
 //! [the examples]: https://github.com/Boscop/web-view/tree/master/examples

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -1,3 +1,10 @@
+//! Raw FFI bindings to [webview].
+//!
+//! To use a custom version of webview, define an environment variable `WEBVIEW_DIR` with the path
+//! to its source directory.
+//!
+//! [webview]: https://github.com/zserge/webview
+
 #[macro_use]
 extern crate bitflags;
 


### PR DESCRIPTION
Modifies the `webview-sys` build script to check for an environment variable `WEBVIEW_DIR` pointing to the webview source to compile against.

Fixes #34 
Provides workaround for #38 