### PR TITLE
Use C calling convention for callbacks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,7 @@ fn read_str(s: &[u8]) -> String {
     }
 }
 
-extern "system" fn ffi_dispatch_handler<T>(webview: *mut CWebView, arg: *mut c_void) {
+extern "C" fn ffi_dispatch_handler<T>(webview: *mut CWebView, arg: *mut c_void) {
     unsafe {
         let mut handle = mem::ManuallyDrop::new(WebView::<T>::from_ptr(webview));
         let result = {
@@ -540,7 +540,7 @@ extern "system" fn ffi_dispatch_handler<T>(webview: *mut CWebView, arg: *mut c_v
     }
 }
 
-extern "system" fn ffi_invoke_handler<T>(webview: *mut CWebView, arg: *const c_char) {
+extern "C" fn ffi_invoke_handler<T>(webview: *mut CWebView, arg: *const c_char) {
     unsafe {
         let arg = CStr::from_ptr(arg).to_string_lossy().to_string();
         let mut handle = mem::ManuallyDrop::new(WebView::<T>::from_ptr(webview));

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -12,8 +12,8 @@ use std::os::raw::*;
 
 pub enum CWebView {} // opaque type, only used in ffi pointers
 
-type ErasedExternalInvokeFn = extern "system" fn(webview: *mut CWebView, arg: *const c_char);
-type ErasedDispatchFn = extern "system" fn(webview: *mut CWebView, arg: *mut c_void);
+type ErasedExternalInvokeFn = extern "C" fn(webview: *mut CWebView, arg: *const c_char);
+type ErasedDispatchFn = extern "C" fn(webview: *mut CWebView, arg: *mut c_void);
 
 #[repr(C)]
 pub enum DialogType {


### PR DESCRIPTION
This fixes crashes on 32bit Windows (reported in #3)