### PR TITLE
fix "too many arguments to function call" on Catalina

### DIFF
--- a/webview-sys/build.rs
+++ b/webview-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
     } else if target.contains("apple") {
         build
             .define("WEBVIEW_COCOA", None)
+            .define("OBJC_OLD_DISPATCH_PROTOTYPES", "1")
             .flag("-x")
             .flag("objective-c");
         println!("cargo:rustc-link-lib=framework=Cocoa");


### PR DESCRIPTION
MacOS 10.15 enables objc_msgSend type checking by default. Every call to objc_msgSend would require a cast. This disables the type checking.

```
cargo:warning=In file included from webview.c:2:
cargo:warning=webview/webview.h:1755:43: error: too many arguments to function call, expected 0, have 2
cargo:warning=                   id path = objc_msgSend(url, sel_registerName("path"));
cargo:warning=                             ~~~~~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cargo:warning=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/objc/message.h:62:1: note: 'objc_msgSend' declared here
cargo:warning=OBJC_EXPORT void
cargo:warning=^
cargo:warning=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/objc/objc-api.h:236:25: note: expanded from macro 'OBJC_EXPORT'
cargo:warning=#   define OBJC_EXPORT  OBJC_EXTERN OBJC_VISIBLE
cargo:warning=                        ^
cargo:warning=/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/objc/objc-api.h:225:28: note: expanded from macro 'OBJC_EXTERN'
cargo:warning=#       define OBJC_EXTERN extern
cargo:warning=                           ^
```