### PR TITLE
Implement EdgeHTML windows backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ boxfnonce = "0.1"
 [features]
 default = ["V1_30"]
 V1_30 = []
+edge = ["webview-sys/edge"]
 
 [dev-dependencies]
 serde = "1.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This library provides Rust bindings for the [webview](https://github.com/zserge/
 
 It supports two-way bindings for communication between the Rust backend and JavaScript frontend.
 
-It uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and MSHTML (IE10/11) on Windows, so your app will be **much** leaner than with Electron.
+It uses Cocoa/WebKit on macOS, gtk-webkit2 on Linux and MSHTML (IE10/11) or EdgeHTML (with the `edge` feature) on Windows, so your app will be **much** leaner than with Electron.
 
 For usage info please check out [the examples](../../tree/master/examples) and the [original readme](https://github.com/zserge/webview/blob/master/README.md).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,14 @@ $ cargo run --example elm-counter
 ```
 
 ## actix
+
 Uses [rust-embed](https://github.com/pyros2097/rust-embed) and [actix-web](https://github.com/actix/actix-web) to embed files directly in binary and serve them to web-view.
+
+Unfortunately if you run this with the EdgeHTML backend (`edge` feature) it won't work by default due to webview sandbox restrictions.
+
+In order for this to run on EdgeHTML, you need to run `CheckNetIsolation.exe LoopbackExempt -a -n="Microsoft.Win32WebViewHost_cw5n1h2txyewy"` from your administrator command prompt only once and everything works.
+
+You can make this step for example as a part of your apps installer.
 
 ---
 

--- a/webview-sys/Cargo.toml
+++ b/webview-sys/Cargo.toml
@@ -14,6 +14,9 @@ links = "webview"
 name = "webview_sys"
 path = "lib.rs"
 
+[features]
+edge = []
+
 [dependencies]
 bitflags = "1.0"
 

--- a/webview-sys/build.rs
+++ b/webview-sys/build.rs
@@ -6,7 +6,7 @@ use std::env;
 fn main() {
     let mut build = cc::Build::new();
 
-    if cfg!(feature = "edge") {
+    if target.contains("windows") && cfg!(feature = "edge") {
         build
             .include("webview_edge.h")
             .file("webview_edge.cc")

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -4,14 +4,12 @@
 extern "C" {
 #endif
 
-typedef void (*webview_external_invoke_cb_t)(webview_t w, void* arg);
-
 void wrapper_webview_free(webview_t w) {
 	webview_destroy(w);
 }
 
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
-	webview_t w = webview_create(debug, nullptr);
+	webview_t w = webview_create(debug, external_invoke_cb, nullptr);
 	webview_set_userdata(w, userdata);
 	webview_set_title(w, title);
 	webview_set_bounds(w, 50, 50, width, height, 0);

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -22,6 +22,10 @@ void* wrapper_webview_get_userdata(webview_t w) {
 	return nullptr;
 }
 
+void webview_exit(webview_t w) {
+	webview_terminate(w);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -24,11 +24,6 @@ void webview_exit(webview_t w) {
 	webview_terminate(w);
 }
 
-void webview_set_color(webview_t w, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
-{
-	// TODO
-}
-
 void webview_dialog(webview_t w, int dlgtype, int flags, const char *title, const char *arg, char *result, size_t resultsz)
 {
 	// TODO

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -11,7 +11,6 @@ void wrapper_webview_free(webview_t w) {
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 	webview_t w = webview_create(external_invoke_cb, title, width, height, resizable, debug);
 	webview_set_userdata(w, userdata);
-	webview_set_title(w, title);
 	webview_navigate(w, url);
 	return w;
 }
@@ -22,52 +21,6 @@ void* wrapper_webview_get_userdata(webview_t w) {
 
 void webview_exit(webview_t w) {
 	webview_terminate(w);
-}
-
-static int webview_js_encode(const char *s, char *esc, size_t n) {
-  int r = 1; /* At least one byte for trailing zero */
-  for (; *s; s++) {
-    const unsigned char c = *s;
-    if (c >= 0x20 && c < 0x80 && strchr("<>\\'\"", c) == NULL) {
-      if (n > 0) {
-        *esc++ = c;
-        n--;
-      }
-      r++;
-    } else {
-      if (n > 0) {
-        snprintf(esc, n, "\\x%02x", (int)c);
-        esc += 4;
-        n -= 4;
-      }
-      r += 4;
-    }
-  }
-  return r;
-}
-
-#define CSS_INJECT_FUNCTION                                                    \
-  "(function(e){var "                                                          \
-  "t=document.createElement('style'),d=document.head||document."               \
-  "getElementsByTagName('head')[0];t.setAttribute('type','text/"               \
-  "css'),t.styleSheet?t.styleSheet.cssText=e:t.appendChild(document."          \
-  "createTextNode(e)),d.appendChild(t)})"
-
-
-int webview_inject_css(webview_t w, const char *css) {
-  int n = webview_js_encode(css, NULL, 0);
-  char *esc = (char *)calloc(1, sizeof(CSS_INJECT_FUNCTION) + n + 4);
-  if (esc == NULL) {
-    return -1;
-  }
-  char *js = (char *)calloc(1, n);
-  webview_js_encode(css, js, n);
-  snprintf(esc, sizeof(CSS_INJECT_FUNCTION) + n + 4, "%s(\"%s\")",
-           CSS_INJECT_FUNCTION, js);
-  int r = webview_eval(w, esc);
-  free(js);
-  free(esc);
-  return r;
 }
 
 #ifdef __cplusplus

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -29,10 +29,50 @@ void webview_dialog(webview_t w, int dlgtype, int flags, const char *title, cons
 	// TODO
 }
 
-int webview_inject_css(webview_t w, const char *css)
-{
-	// TODO
-	return 0;
+static int webview_js_encode(const char *s, char *esc, size_t n) {
+  int r = 1; /* At least one byte for trailing zero */
+  for (; *s; s++) {
+    const unsigned char c = *s;
+    if (c >= 0x20 && c < 0x80 && strchr("<>\\'\"", c) == NULL) {
+      if (n > 0) {
+        *esc++ = c;
+        n--;
+      }
+      r++;
+    } else {
+      if (n > 0) {
+        snprintf(esc, n, "\\x%02x", (int)c);
+        esc += 4;
+        n -= 4;
+      }
+      r += 4;
+    }
+  }
+  return r;
+}
+
+#define CSS_INJECT_FUNCTION                                                    \
+  "(function(e){var "                                                          \
+  "t=document.createElement('style'),d=document.head||document."               \
+  "getElementsByTagName('head')[0];t.setAttribute('type','text/"               \
+  "css'),t.styleSheet?t.styleSheet.cssText=e:t.appendChild(document."          \
+  "createTextNode(e)),d.appendChild(t)})"
+
+
+int webview_inject_css(webview_t w, const char *css) {
+  int n = webview_js_encode(css, NULL, 0);
+  char *esc = (char *)calloc(1, sizeof(CSS_INJECT_FUNCTION) + n + 4);
+  if (esc == NULL) {
+    return -1;
+  }
+  char *js = (char *)calloc(1, n);
+  webview_js_encode(css, js, n);
+  snprintf(esc, sizeof(CSS_INJECT_FUNCTION) + n + 4, "%s(\"%s\")",
+           CSS_INJECT_FUNCTION, js);
+  int r = webview_eval(w, esc);
+  free(js);
+  free(esc);
+  return r;
 }
 
 #ifdef __cplusplus

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -12,6 +12,7 @@ void wrapper_webview_free(webview_t w) {
 
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 	webview_t w = webview_create(debug, nullptr);
+	webview_set_userdata(w, userdata);
 	webview_set_title(w, title);
 	webview_set_bounds(w, 50, 50, width, height, 0);
 	webview_navigate(w, url);
@@ -19,7 +20,7 @@ webview_t wrapper_webview_new(const char* title, const char* url, int width, int
 }
 
 void* wrapper_webview_get_userdata(webview_t w) {
-	return nullptr;
+	return webview_get_userdata(w);
 }
 
 void webview_exit(webview_t w) {

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -9,7 +9,7 @@ void wrapper_webview_free(webview_t w) {
 }
 
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
-	webview_t w = webview_create(external_invoke_cb, width, height, resizable, debug);
+	webview_t w = webview_create(external_invoke_cb, title, width, height, resizable, debug);
 	webview_set_userdata(w, userdata);
 	webview_set_title(w, title);
 	webview_navigate(w, url);

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -1,0 +1,27 @@
+#include "webview_edge.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*webview_external_invoke_cb_t)(webview_t w, void* arg);
+
+void wrapper_webview_free(webview_t w) {
+	webview_destroy(w);
+}
+
+webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
+	webview_t w = webview_create(debug, nullptr);
+	webview_set_title(w, title);
+	webview_set_bounds(w, 50, 50, width, height, 0);
+	webview_navigate(w, url);
+	return w;
+}
+
+void* wrapper_webview_get_userdata(webview_t w) {
+	return nullptr;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -34,11 +34,6 @@ void webview_dialog(webview_t w, int dlgtype, int flags, const char *title, cons
 	// TODO
 }
 
-void webview_set_fullscreen(webview_t w, int fullscreen)
-{
-	// TODO
-}
-
 int webview_inject_css(webview_t w, const char *css)
 {
 	// TODO

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -9,7 +9,7 @@ void wrapper_webview_free(webview_t w) {
 }
 
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
-	webview_t w = webview_create(debug, external_invoke_cb, nullptr);
+	webview_t w = webview_create(external_invoke_cb, debug, nullptr);
 	webview_set_userdata(w, userdata);
 	webview_set_title(w, title);
 	webview_set_bounds(w, 50, 50, width, height, 0);

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -24,11 +24,6 @@ void webview_exit(webview_t w) {
 	webview_terminate(w);
 }
 
-void webview_dialog(webview_t w, int dlgtype, int flags, const char *title, const char *arg, char *result, size_t resultsz)
-{
-	// TODO
-}
-
 static int webview_js_encode(const char *s, char *esc, size_t n) {
   int r = 1; /* At least one byte for trailing zero */
   for (; *s; s++) {

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -9,10 +9,9 @@ void wrapper_webview_free(webview_t w) {
 }
 
 webview_t wrapper_webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
-	webview_t w = webview_create(external_invoke_cb, debug, nullptr);
+	webview_t w = webview_create(external_invoke_cb, width, height, resizable, debug);
 	webview_set_userdata(w, userdata);
 	webview_set_title(w, title);
-	webview_set_bounds(w, 50, 50, width, height, 0);
 	webview_navigate(w, url);
 	return w;
 }

--- a/webview-sys/webview_edge.cc
+++ b/webview-sys/webview_edge.cc
@@ -27,6 +27,27 @@ void webview_exit(webview_t w) {
 	webview_terminate(w);
 }
 
+void webview_set_color(webview_t w, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+	// TODO
+}
+
+void webview_dialog(webview_t w, int dlgtype, int flags, const char *title, const char *arg, char *result, size_t resultsz)
+{
+	// TODO
+}
+
+void webview_set_fullscreen(webview_t w, int fullscreen)
+{
+	// TODO
+}
+
+int webview_inject_css(webview_t w, const char *css)
+{
+	// TODO
+	return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -593,7 +593,9 @@ public:
         , invoke_cb(invoke_cb)
     {
         init_apartment(winrt::apartment_type::single_threaded);
-        m_process = WebViewControlProcess();
+        WebViewControlProcessOptions options;
+        options.PrivateNetworkClientServerCapability(WebViewControlProcessCapabilityState::Enabled);
+        m_process = WebViewControlProcess(options);
         auto op = m_process.CreateWebViewControlAsync(
             reinterpret_cast<int64_t>(m_window), Rect());
         if (op.Status() != AsyncStatus::Completed) {

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -1,0 +1,672 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2017 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef WEBVIEW_H
+#define WEBVIEW_H
+
+#ifndef WEBVIEW_API
+#define WEBVIEW_API extern
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* webview_t;
+
+// Create a new webview instance
+WEBVIEW_API webview_t webview_create(int debug, void* wnd);
+
+// Destroy a webview
+WEBVIEW_API void webview_destroy(webview_t w);
+
+// Run the main loop
+WEBVIEW_API void webview_run(webview_t w);
+
+// Stop the main loop
+WEBVIEW_API void webview_terminate(webview_t w);
+
+// Post a function to be executed on the main thread
+WEBVIEW_API void webview_dispatch(
+    webview_t w, void (*fn)(webview_t w, void* arg), void* arg);
+
+WEBVIEW_API void* webview_get_window(webview_t w);
+
+WEBVIEW_API void webview_set_title(webview_t w, const char* title);
+
+WEBVIEW_API void webview_set_bounds(
+    webview_t w, int x, int y, int width, int height, int flags);
+WEBVIEW_API void webview_get_bounds(
+    webview_t w, int* x, int* y, int* width, int* height, int* flags);
+
+WEBVIEW_API void webview_navigate(webview_t w, const char* url);
+WEBVIEW_API void webview_init(webview_t w, const char* js);
+WEBVIEW_API void webview_eval(webview_t w, const char* js);
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifndef WEBVIEW_HEADER
+
+#include <atomic>
+#include <cstring>
+#include <functional>
+#include <future>
+#include <map>
+#include <string>
+#include <vector>
+
+//
+// ====================================================================
+//
+// This implementation uses Win32 API to create a native window. It can
+// use either MSHTML or EdgeHTML backend as a browser engine.
+//
+// ====================================================================
+//
+
+#define WIN32_LEAN_AND_MEAN
+#include <objbase.h>
+#include <windows.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Web.UI.Interop.h>
+
+#pragma comment(lib, "windowsapp")
+#pragma comment(lib, "user32.lib")
+
+namespace webview {
+using dispatch_fn_t = std::function<void()>;
+using msg_cb_t = std::function<void(const char* msg)>;
+
+inline std::string url_encode(std::string s)
+{
+    std::string encoded;
+    for (unsigned int i = 0; i < s.length(); i++) {
+        auto c = s[i];
+        if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            encoded = encoded + c;
+        } else {
+            char hex[4];
+            snprintf(hex, sizeof(hex), "%%%02x", c);
+            encoded = encoded + hex;
+        }
+    }
+    return encoded;
+}
+
+inline std::string url_decode(std::string s)
+{
+    std::string decoded;
+    for (unsigned int i = 0; i < s.length(); i++) {
+        if (s[i] == '%') {
+            int n;
+            sscanf(s.substr(i + 1, 2).c_str(), "%x", &n);
+            decoded = decoded + static_cast<char>(n);
+            i = i + 2;
+        } else if (s[i] == '+') {
+            decoded = decoded + ' ';
+        } else {
+            decoded = decoded + s[i];
+        }
+    }
+    return decoded;
+}
+
+inline std::string html_from_uri(std::string s)
+{
+    if (s.substr(0, 15) == "data:text/html,") {
+        return url_decode(s.substr(15));
+    }
+    return "";
+}
+
+inline int json_parse_c(const char* s, size_t sz, const char* key, size_t keysz,
+    const char** value, size_t* valuesz)
+{
+    enum {
+        JSON_STATE_VALUE,
+        JSON_STATE_LITERAL,
+        JSON_STATE_STRING,
+        JSON_STATE_ESCAPE,
+        JSON_STATE_UTF8
+    } state
+        = JSON_STATE_VALUE;
+    const char* k = NULL;
+    int index = 1;
+    int depth = 0;
+    int utf8_bytes = 0;
+
+    if (key == NULL) {
+        index = keysz;
+        keysz = 0;
+    }
+
+    *value = NULL;
+    *valuesz = 0;
+
+    for (; sz > 0; s++, sz--) {
+        enum {
+            JSON_ACTION_NONE,
+            JSON_ACTION_START,
+            JSON_ACTION_END,
+            JSON_ACTION_START_STRUCT,
+            JSON_ACTION_END_STRUCT
+        } action
+            = JSON_ACTION_NONE;
+        unsigned char c = *s;
+        switch (state) {
+        case JSON_STATE_VALUE:
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' || c == ':') {
+                continue;
+            } else if (c == '"') {
+                action = JSON_ACTION_START;
+                state = JSON_STATE_STRING;
+            } else if (c == '{' || c == '[') {
+                action = JSON_ACTION_START_STRUCT;
+            } else if (c == '}' || c == ']') {
+                action = JSON_ACTION_END_STRUCT;
+            } else if (c == 't' || c == 'f' || c == 'n' || c == '-'
+                || (c >= '0' && c <= '9')) {
+                action = JSON_ACTION_START;
+                state = JSON_STATE_LITERAL;
+            } else {
+                return -1;
+            }
+            break;
+        case JSON_STATE_LITERAL:
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ',' || c == ']'
+                || c == '}' || c == ':') {
+                state = JSON_STATE_VALUE;
+                s--;
+                sz++;
+                action = JSON_ACTION_END;
+            } else if (c < 32 || c > 126) {
+                return -1;
+            } // fallthrough
+        case JSON_STATE_STRING:
+            if (c < 32 || (c > 126 && c < 192)) {
+                return -1;
+            } else if (c == '"') {
+                action = JSON_ACTION_END;
+                state = JSON_STATE_VALUE;
+            } else if (c == '\\') {
+                state = JSON_STATE_ESCAPE;
+            } else if (c >= 192 && c < 224) {
+                utf8_bytes = 1;
+                state = JSON_STATE_UTF8;
+            } else if (c >= 224 && c < 240) {
+                utf8_bytes = 2;
+                state = JSON_STATE_UTF8;
+            } else if (c >= 240 && c < 247) {
+                utf8_bytes = 3;
+                state = JSON_STATE_UTF8;
+            } else if (c >= 128 && c < 192) {
+                return -1;
+            }
+            break;
+        case JSON_STATE_ESCAPE:
+            if (c == '"' || c == '\\' || c == '/' || c == 'b' || c == 'f' || c == 'n'
+                || c == 'r' || c == 't' || c == 'u') {
+                state = JSON_STATE_STRING;
+            } else {
+                return -1;
+            }
+            break;
+        case JSON_STATE_UTF8:
+            if (c < 128 || c > 191) {
+                return -1;
+            }
+            utf8_bytes--;
+            if (utf8_bytes == 0) {
+                state = JSON_STATE_STRING;
+            }
+            break;
+        default:
+            return -1;
+        }
+
+        if (action == JSON_ACTION_END_STRUCT) {
+            depth--;
+        }
+
+        if (depth == 1) {
+            if (action == JSON_ACTION_START || action == JSON_ACTION_START_STRUCT) {
+                if (index == 0) {
+                    *value = s;
+                } else if (keysz > 0 && index == 1) {
+                    k = s;
+                } else {
+                    index--;
+                }
+            } else if (action == JSON_ACTION_END || action == JSON_ACTION_END_STRUCT) {
+                if (*value != NULL && index == 0) {
+                    *valuesz = (size_t)(s + 1 - *value);
+                    return 0;
+                } else if (keysz > 0 && k != NULL) {
+                    if (keysz == (size_t)(s - k - 1) && memcmp(key, k + 1, keysz) == 0) {
+                        index = 0;
+                    } else {
+                        index = 2;
+                    }
+                    k = NULL;
+                }
+            }
+        }
+
+        if (action == JSON_ACTION_START_STRUCT) {
+            depth++;
+        }
+    }
+    return -1;
+}
+
+inline std::string json_escape(std::string s)
+{
+    // TODO: implement
+    return '"' + s + '"';
+}
+
+inline int json_unescape(const char* s, size_t n, char* out)
+{
+    int r = 0;
+    if (*s++ != '"') {
+        return -1;
+    }
+    while (n > 2) {
+        char c = *s;
+        if (c == '\\') {
+            s++;
+            n--;
+            switch (*s) {
+            case 'b':
+                c = '\b';
+                break;
+            case 'f':
+                c = '\f';
+                break;
+            case 'n':
+                c = '\n';
+                break;
+            case 'r':
+                c = '\r';
+                break;
+            case 't':
+                c = '\t';
+                break;
+            case '\\':
+                c = '\\';
+                break;
+            case '/':
+                c = '/';
+                break;
+            case '\"':
+                c = '\"';
+                break;
+            default: // TODO: support unicode decoding
+                return -1;
+            }
+        }
+        if (out != NULL) {
+            *out++ = c;
+        }
+        s++;
+        n--;
+        r++;
+    }
+    if (*s != '"') {
+        return -1;
+    }
+    if (out != NULL) {
+        *out = '\0';
+    }
+    return r;
+}
+
+inline std::string json_parse(std::string s, std::string key, int index)
+{
+    const char* value;
+    size_t value_sz;
+    if (key == "") {
+        json_parse_c(s.c_str(), s.length(), nullptr, index, &value, &value_sz);
+    } else {
+        json_parse_c(s.c_str(), s.length(), key.c_str(), key.length(), &value, &value_sz);
+    }
+    if (value != nullptr) {
+        if (value[0] != '"') {
+            return std::string(value, value_sz);
+        }
+        int n = json_unescape(value, value_sz, nullptr);
+        if (n > 0) {
+            char* decoded = new char[n];
+            json_unescape(value, value_sz, decoded);
+            auto result = std::string(decoded, n);
+            delete[] decoded;
+            return result;
+        }
+    }
+    return "";
+}
+
+LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
+class browser_window {
+public:
+    browser_window(msg_cb_t cb, void* window)
+        : m_cb(cb)
+    {
+        if (window == nullptr) {
+            WNDCLASSEX wc;
+            ZeroMemory(&wc, sizeof(WNDCLASSEX));
+            wc.cbSize = sizeof(WNDCLASSEX);
+            wc.hInstance = GetModuleHandle(nullptr);
+            wc.lpszClassName = "webview";
+            wc.lpfnWndProc = WebviewWndProc;
+            RegisterClassEx(&wc);
+            m_window = CreateWindow("webview", "", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+                CW_USEDEFAULT, 640, 480, nullptr, nullptr, GetModuleHandle(nullptr),
+                nullptr);
+            SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
+        } else {
+            m_window = *(static_cast<HWND*>(window));
+        }
+
+        ShowWindow(m_window, SW_SHOW);
+        UpdateWindow(m_window);
+        SetFocus(m_window);
+    }
+
+    void run()
+    {
+        MSG msg;
+        BOOL res;
+        while ((res = GetMessage(&msg, nullptr, 0, 0)) != -1) {
+            if (msg.hwnd) {
+                TranslateMessage(&msg);
+                DispatchMessage(&msg);
+                continue;
+            }
+            if (msg.message == WM_APP) {
+                auto f = (dispatch_fn_t*)(msg.lParam);
+                (*f)();
+                delete f;
+            } else if (msg.message == WM_QUIT) {
+                return;
+            }
+        }
+    }
+
+    void terminate() { PostQuitMessage(0); }
+    void dispatch(dispatch_fn_t f)
+    {
+        PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
+    }
+
+    void set_title(const char* title) { SetWindowText(m_window, title); }
+
+    void set_size(int width, int height, bool resizable)
+    {
+        RECT r;
+        r.left = 50;
+        r.top = 50;
+        r.right = width;
+        r.bottom = height;
+        AdjustWindowRect(&r, WS_OVERLAPPEDWINDOW, 0);
+        SetWindowPos(m_window, NULL, r.left, r.top, r.right - r.left, r.bottom - r.top,
+            SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+    }
+
+    // protected:
+    virtual void resize() {}
+    HWND m_window;
+    DWORD m_main_thread = GetCurrentThreadId();
+    msg_cb_t m_cb;
+};
+
+LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
+{
+    auto w = (browser_window*)GetWindowLongPtr(hwnd, GWLP_USERDATA);
+    switch (msg) {
+    case WM_SIZE:
+        w->resize();
+        break;
+    case WM_CLOSE:
+        DestroyWindow(hwnd);
+        break;
+    case WM_DESTROY:
+        w->terminate();
+        break;
+    default:
+        return DefWindowProc(hwnd, msg, wp, lp);
+    }
+    return 0;
+}
+
+using namespace winrt;
+using namespace Windows::Foundation;
+using namespace Windows::Web::UI;
+using namespace Windows::Web::UI::Interop;
+
+class browser_engine : public browser_window {
+public:
+    browser_engine(msg_cb_t cb, bool debug, void* window)
+        : browser_window(cb, window)
+    {
+        init_apartment(winrt::apartment_type::single_threaded);
+        m_process = WebViewControlProcess();
+        auto op = m_process.CreateWebViewControlAsync(
+            reinterpret_cast<int64_t>(m_window), Rect());
+        if (op.Status() != AsyncStatus::Completed) {
+            handle h(CreateEvent(nullptr, false, false, nullptr));
+            op.Completed([h = h.get()](auto, auto) { SetEvent(h); });
+            HANDLE hs[] = { h.get() };
+            DWORD i;
+            CoWaitForMultipleHandles(COWAIT_DISPATCH_WINDOW_MESSAGES
+                    | COWAIT_DISPATCH_CALLS | COWAIT_INPUTAVAILABLE,
+                INFINITE, 1, hs, &i);
+        }
+        m_webview = op.GetResults();
+        m_webview.Settings().IsScriptNotifyAllowed(true);
+        m_webview.IsVisible(true);
+        m_webview.ScriptNotify([=](auto const& sender, auto const& args) {
+            std::string s = winrt::to_string(args.Value());
+            m_cb(s.c_str());
+        });
+        m_webview.NavigationStarting([=](auto const& sender, auto const& args) {
+            m_webview.AddInitializeScript(winrt::to_hstring(init_js));
+        });
+        init("window.external.invoke = s => window.external.notify(s)");
+        resize();
+    }
+
+    void navigate(const char* url)
+    {
+        Uri uri(winrt::to_hstring(url));
+        // TODO: if url starts with 'data:text/html,' prefix then use it as a
+        // string
+        m_webview.Navigate(uri);
+        // m_webview.NavigateToString(winrt::to_hstring(url));
+    }
+    void init(const char* js) { init_js = init_js + "(function(){" + js + "})();"; }
+    void eval(const char* js)
+    {
+        m_webview.InvokeScriptAsync(
+            L"eval", single_threaded_vector<hstring>({ winrt::to_hstring(js) }));
+    }
+
+private:
+    void resize()
+    {
+        RECT r;
+        GetClientRect(m_window, &r);
+        Rect bounds(r.left, r.top, r.right - r.left, r.bottom - r.top);
+        m_webview.Bounds(bounds);
+    }
+    WebViewControlProcess m_process;
+    WebViewControl m_webview = nullptr;
+    std::string init_js = "";
+};
+
+class webview : public browser_engine {
+public:
+    webview(bool debug = false, void* wnd = nullptr)
+        : browser_engine(
+            std::bind(&webview::on_message, this, std::placeholders::_1), debug, wnd)
+    {
+    }
+
+    void* window() { return (void*)m_window; }
+
+    void navigate(const char* url)
+    {
+        std::string html = html_from_uri(url);
+        if (html != "") {
+            browser_engine::navigate(("data:text/html," + url_encode(html)).c_str());
+        } else {
+            browser_engine::navigate(url);
+        }
+    }
+
+    using binding_t = std::function<std::string(std::string)>;
+
+    void bind(const char* name, binding_t f)
+    {
+        auto js = "(function() { var name = '" + std::string(name) + "';" + R"(
+      window[name] = function() {
+        var me = window[name];
+        var errors = me['errors'];
+        var callbacks = me['callbacks'];
+        if (!callbacks) {
+          callbacks = {};
+          me['callbacks'] = callbacks;
+        }
+        if (!errors) {
+          errors = {};
+          me['errors'] = errors;
+        }
+        var seq = (me['lastSeq'] || 0) + 1;
+        me['lastSeq'] = seq;
+        var promise = new Promise(function(resolve, reject) {
+          callbacks[seq] = resolve;
+          errors[seq] = reject;
+        });
+        window.external.invoke(JSON.stringify({
+          name: name,
+          seq:seq,
+          args: Array.prototype.slice.call(arguments),
+        }));
+        return promise;
+      }
+    })())";
+        init(js.c_str());
+        bindings[name] = new binding_t(f);
+    }
+
+private:
+    void on_message(const char* msg)
+    {
+        auto seq = json_parse(msg, "seq", 0);
+        auto name = json_parse(msg, "name", 0);
+        auto args = json_parse(msg, "args", 0);
+        auto fn = bindings[name];
+        if (fn == nullptr) {
+            return;
+        }
+        std::async(std::launch::async, [=]() {
+            auto result = (*fn)(args);
+            dispatch([=]() {
+                eval(("var b = window['" + name + "'];b['callbacks'][" + seq + "]("
+                    + result + ");b['callbacks'][" + seq + "] = undefined;b['errors']["
+                    + seq + "] = undefined;")
+                         .c_str());
+            });
+        });
+    }
+    std::map<std::string, binding_t*> bindings;
+};
+
+} // namespace webview
+
+WEBVIEW_API webview_t webview_create(int debug, void* wnd)
+{
+    return new webview::webview(debug, wnd);
+}
+
+WEBVIEW_API void webview_destroy(webview_t w)
+{
+    delete static_cast<webview::webview*>(w);
+}
+
+WEBVIEW_API void webview_run(webview_t w) { static_cast<webview::webview*>(w)->run(); }
+
+WEBVIEW_API void webview_terminate(webview_t w)
+{
+    static_cast<webview::webview*>(w)->terminate();
+}
+
+WEBVIEW_API void webview_dispatch(
+    webview_t w, void (*fn)(webview_t w, void* arg), void* arg)
+{
+    static_cast<webview::webview*>(w)->dispatch([=]() { fn(w, arg); });
+}
+
+WEBVIEW_API void* webview_get_window(webview_t w)
+{
+    return static_cast<webview::webview*>(w)->window();
+}
+
+WEBVIEW_API void webview_set_title(webview_t w, const char* title)
+{
+    static_cast<webview::webview*>(w)->set_title(title);
+}
+
+WEBVIEW_API void webview_set_bounds(
+    webview_t w, int x, int y, int width, int height, int flags)
+{
+    // TODO: x, y, flags
+    static_cast<webview::webview*>(w)->set_size(width, height, true);
+}
+
+WEBVIEW_API void webview_get_bounds(
+    webview_t w, int* x, int* y, int* width, int* height, int* flags)
+{
+    // TODO
+}
+
+WEBVIEW_API void webview_navigate(webview_t w, const char* url)
+{
+    static_cast<webview::webview*>(w)->navigate(url);
+}
+
+WEBVIEW_API void webview_init(webview_t w, const char* js)
+{
+    static_cast<webview::webview*>(w)->init(js);
+}
+
+WEBVIEW_API void webview_eval(webview_t w, const char* js)
+{
+    static_cast<webview::webview*>(w)->eval(js);
+}
+
+#endif /* WEBVIEW_HEADER */
+
+#endif /* WEBVIEW_H */

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -378,7 +378,7 @@ inline std::string json_parse(std::string s, std::string key, int index)
 LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp);
 class browser_window {
 public:
-    browser_window(msg_cb_t cb, int width, int height, bool resizable)
+    browser_window(msg_cb_t cb, const char* title, int width, int height, bool resizable)
         : m_cb(cb)
     {
         HINSTANCE hInstance = GetModuleHandle(nullptr);
@@ -412,7 +412,7 @@ public:
         rect.bottom = rect.bottom - rect.top + top;
         rect.top = top;
 
-        m_window = CreateWindowEx(0, "webview", "title", style, rect.left, rect.top,
+        m_window = CreateWindowEx(0, "webview", title, style, rect.left, rect.top,
                      rect.right - rect.left, rect.bottom - rect.top,
                      HWND_DESKTOP, NULL, hInstance, (void *)this);
 
@@ -525,8 +525,8 @@ using namespace Windows::Web::UI::Interop;
 
 class webview : public browser_window {
 public:
-    webview(webview_external_invoke_cb_t invoke_cb, int width, int height, bool resizable, bool debug)
-        : browser_window(std::bind(&webview::on_message, this, std::placeholders::_1), width, height, resizable)
+    webview(webview_external_invoke_cb_t invoke_cb, const char* title, int width, int height, bool resizable, bool debug)
+        : browser_window(std::bind(&webview::on_message, this, std::placeholders::_1), title, width, height, resizable)
         , invoke_cb(invoke_cb)
     {
         init_apartment(winrt::apartment_type::single_threaded);
@@ -600,9 +600,9 @@ private:
 
 } // namespace webview
 
-WEBVIEW_API webview_t webview_create(webview_external_invoke_cb_t invoke_cb, int width, int height, int resizable, int debug)
+WEBVIEW_API webview_t webview_create(webview_external_invoke_cb_t invoke_cb, const char* title, int width, int height, int resizable, int debug)
 {
-    return new webview::webview(invoke_cb, width, height, resizable, debug);
+    return new webview::webview(invoke_cb, title, width, height, resizable, debug);
 }
 
 WEBVIEW_API void webview_destroy(webview_t w)

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -534,11 +534,13 @@ public:
 
     void navigate(const char* url)
     {
-        Uri uri(winrt::to_hstring(url));
-        // TODO: if url starts with 'data:text/html,' prefix then use it as a
-        // string
-        m_webview.Navigate(uri);
-        // m_webview.NavigateToString(winrt::to_hstring(url));
+        std::string html = html_from_uri(url);
+        if (html != "") {
+            m_webview.NavigateToString(winrt::to_hstring(html.c_str()));
+        } else {
+            Uri uri(winrt::to_hstring(url));
+            m_webview.Navigate(uri);
+        }
     }
     void init(const char* js) { init_js = init_js + "(function(){" + js + "})();"; }
     void eval(const char* js)
@@ -575,12 +577,7 @@ public:
 
     void navigate(const char* url)
     {
-        std::string html = html_from_uri(url);
-        if (html != "") {
-            browser_engine::navigate(("data:text/html," + url_encode(html)).c_str());
-        } else {
-            browser_engine::navigate(url);
-        }
+        browser_engine::navigate(url);
     }
 
     using binding_t = std::function<std::string(std::string)>;

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -28,6 +28,8 @@
 #define WEBVIEW_API extern
 #endif
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -73,6 +75,9 @@ WEBVIEW_API void webview_set_userdata(webview_t w, void* user_data);
 // Enable or disable window fullscreen
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 
+// Set rgba color of the window's title bar
+WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g, uint8_t b, uint8_t a);
+
 #ifdef __cplusplus
 }
 #endif
@@ -99,11 +104,13 @@ WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 #define WIN32_LEAN_AND_MEAN
 #include <objbase.h>
 #include <windows.h>
+#include <wingdi.h>
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Web.UI.Interop.h>
 
 #pragma comment(lib, "windowsapp")
 #pragma comment(lib, "user32.lib")
+#pragma comment(lib, "gdi32")
 
 namespace webview {
 using dispatch_fn_t = std::function<void()>;
@@ -536,6 +543,12 @@ public:
         }
     }
 
+    void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    {
+        HBRUSH brush = CreateSolidBrush(RGB(r, g, b));
+        SetClassLongPtr(this->m_window, GCLP_HBRBACKGROUND, (LONG_PTR)brush);
+    }
+
     // protected:
     virtual void resize() {}
     HWND m_window;
@@ -727,6 +740,11 @@ WEBVIEW_API void webview_set_userdata(webview_t w, void* user_data)
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen)
 {
     static_cast<webview::webview*>(w)->set_fullscreen(fullscreen);
+}
+
+WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    static_cast<webview::webview*>(w)->set_color(r, g, b, a);
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -61,7 +61,7 @@ WEBVIEW_API void webview_get_bounds(
 
 WEBVIEW_API void webview_navigate(webview_t w, const char* url);
 WEBVIEW_API void webview_init(webview_t w, const char* js);
-WEBVIEW_API void webview_eval(webview_t w, const char* js);
+WEBVIEW_API int webview_eval(webview_t w, const char* js);
 
 WEBVIEW_API int webview_loop(webview_t w, int blocking);
 
@@ -696,9 +696,10 @@ WEBVIEW_API void webview_init(webview_t w, const char* js)
     static_cast<webview::webview*>(w)->init(js);
 }
 
-WEBVIEW_API void webview_eval(webview_t w, const char* js)
+WEBVIEW_API int webview_eval(webview_t w, const char* js)
 {
     static_cast<webview::webview*>(w)->eval(js);
+    return 0;
 }
 
 WEBVIEW_API int webview_loop(webview_t w, int blocking) {

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -65,6 +65,9 @@ WEBVIEW_API void webview_eval(webview_t w, const char* js);
 
 WEBVIEW_API int webview_loop(webview_t w, int blocking);
 
+WEBVIEW_API void* webview_get_userdata(webview_t w);
+WEBVIEW_API void webview_set_userdata(webview_t w, void* user_data);
+
 #ifdef __cplusplus
 }
 #endif
@@ -559,10 +562,13 @@ private:
 
 class webview : public browser_engine {
 public:
+    void* user_data;
+
     webview(bool debug = false, void* wnd = nullptr)
         : browser_engine(
             std::bind(&webview::on_message, this, std::placeholders::_1), debug, wnd)
     {
+        user_data = nullptr;
     }
 
     void* window() { return (void*)m_window; }
@@ -700,6 +706,15 @@ WEBVIEW_API void webview_eval(webview_t w, const char* js)
 
 WEBVIEW_API int webview_loop(webview_t w, int blocking) {
 	return static_cast<webview::webview*>(w)->loop(blocking);
+}
+
+WEBVIEW_API void* webview_get_userdata(webview_t w) {
+    return static_cast<webview::webview*>(w)->user_data;
+}
+
+WEBVIEW_API void webview_set_userdata(webview_t w, void* user_data)
+{
+    static_cast<webview::webview*>(w)->user_data = user_data;
 }
 
 #endif /* WEBVIEW_HEADER */

--- a/webview-sys/webview_edge.h
+++ b/webview-sys/webview_edge.h
@@ -583,48 +583,11 @@ public:
     {
         browser_engine::navigate(url);
     }
-
-    using binding_t = std::function<std::string(std::string)>;
-
-    void bind(const char* name, binding_t f)
-    {
-        auto js = "(function() { var name = '" + std::string(name) + "';" + R"(
-      window[name] = function() {
-        var me = window[name];
-        var errors = me['errors'];
-        var callbacks = me['callbacks'];
-        if (!callbacks) {
-          callbacks = {};
-          me['callbacks'] = callbacks;
-        }
-        if (!errors) {
-          errors = {};
-          me['errors'] = errors;
-        }
-        var seq = (me['lastSeq'] || 0) + 1;
-        me['lastSeq'] = seq;
-        var promise = new Promise(function(resolve, reject) {
-          callbacks[seq] = resolve;
-          errors[seq] = reject;
-        });
-        window.external.invoke(JSON.stringify({
-          name: name,
-          seq:seq,
-          args: Array.prototype.slice.call(arguments),
-        }));
-        return promise;
-      }
-    })())";
-        init(js.c_str());
-        bindings[name] = new binding_t(f);
-    }
-
 private:
     void on_message(const char* msg)
     {
         this->invoke_cb(this, msg);
     }
-    std::map<std::string, binding_t*> bindings;
 };
 
 } // namespace webview


### PR DESCRIPTION
Adds edge html backend taken from [zserge/webview](https://github.com/zserge/webview/tree/webview-x) (webview-x branch).

The old backends remain the same, I just took the one implementation and copied here, created c function wrappers compatible with original webview, fixed some bugs that caused crashes and implemented navigation to static base64 encoded content (previously you could only navigate to url).

Some functions are not yet implemented so not everything works.

Things that work:
- Calling into javascript from rust with eval
- All examples except ~~`todo`~~ and `actix` - todo example now works

Things that do not work:
- ~~Calling Rust invoke_handler from webview's javascript~~ - works now
- ~~Fullscreen mode~~ - works now
- ~~Dialogs~~ - works now
- ~~Css injection~~ - works now
- ~~Title bar color~~ - works now