### PR TITLE
Enable webgl and hardware acceleration for webview_gtk canvas

### DIFF
--- a/webview-sys/webview_gtk.c
+++ b/webview-sys/webview_gtk.c
@@ -134,6 +134,13 @@ int webview_init(struct gtk_webview *w) {
                    G_CALLBACK(webview_load_changed_cb), w);
   gtk_container_add(GTK_CONTAINER(w->priv.scroller), w->priv.webview);
 
+  WebKitSettings *settings =
+      webkit_web_view_get_settings(WEBKIT_WEB_VIEW(w->priv.webview));
+
+  // Enable webgl and canvas features.
+  webkit_settings_set_enable_webgl(settings, true);
+  webkit_settings_set_enable_accelerated_2d_canvas(settings, true);
+
   if (w->debug) {
     WebKitSettings *settings =
         webkit_web_view_get_settings(WEBKIT_WEB_VIEW(w->priv.webview));


### PR DESCRIPTION
When attempting to make use of webgl with the webkit/gtk backend, the feature is unavailable.
This enables webgl (WebGL, not WebGL2), and hardware acceleration for canvas.

It may be desirable to move this behind a setting for the `WebViewBuilder`, but decided against it because I am unsure whether WebGL is enabled and available on the other backends. 