### PR TITLE
Fix Edge backend process leak

### DIFF
--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -528,6 +528,11 @@ public:
             L"eval", single_threaded_vector<hstring>({ winrt::to_hstring(js) }));
     }
 
+    void terminate() {
+        browser_window::terminate();
+        m_webview.Close();
+    }
+
     void* window() { return (void*)m_window; }
 
     void* get_user_data() { return this->user_data; }


### PR DESCRIPTION
Addresses #74 

With this change, the processes `WWAHost.exe` and `Win32WebViewHost.exe` are properly ended when `WebView::terminate()` is used to close the web view.

Only one instance of the `RuntimeBroker.exe` process will remain open if multiple web views are opened and closed.