### PR TITLE
Fixed outdated parameter types found while cross compiling to windows

### DIFF
--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1240,7 +1240,7 @@ WEBVIEW_API void webview_dialog(webview_t w,
 
 WEBVIEW_API void webview_terminate(webview_t w) { (void)w; PostQuitMessage(0); }
 
-WEBVIEW_API void webview_exit(struct mshtml_webview *w) {
+WEBVIEW_API void webview_exit(webview_t w) {
   struct mshtml_webview* wv = (struct mshtml_webview*)w;
   if (wv->title != NULL)
   {


### PR DESCRIPTION
I haven't looked at the result of the change, the method body may need attention. I am testing this out on some systems and wanted a windows `.exe` without the pain of actually developing on a windows box.

Compile error observed when cross compiling with `cross build --target=x86_64-pc-windows-gnu --release`:

```
webview_mshtml.c: In function 'Site_QueryInterface':
webview_mshtml.c:254:0: note: -Wmisleading-indentation is disabled from this point onwards, since column-tracking was disabled due to the size of the code/headers
   return S_OK;
 
webview_mshtml.c: At top level:
webview_mshtml.c:1237:0: error: conflicting types for 'webview_exit'
 WEBVIEW_API void webview_exit(struct mshtml_webview *w) {
 
In file included from webview_mshtml.c:1:0:
webview.h:42:18: note: previous declaration of 'webview_exit' was here
 WEBVIEW_API void webview_exit(webview_t w);
                  ^~~~~~~~~~~~
exit code: 1
```