### PR TITLE
Fix linked libraries

### DIFF
--- a/webview-sys/build.rs
+++ b/webview-sys/build.rs
@@ -26,10 +26,14 @@ fn main() {
             build
                 .file("webview_edge.cpp")
                 .flag_if_supported("/std:c++17");
+
+            for &lib in &["windowsapp", "user32", "gdi32", "ole32"] {
+                println!("cargo:rustc-link-lib={}", lib);
+            }
         } else {
             build.file("webview_mshtml.c");
 
-            for &lib in &["ole32", "comctl32", "oleaut32", "uuid", "gdi32"] {
+            for &lib in &["ole32", "comctl32", "oleaut32", "uuid", "gdi32", "user32"] {
                 println!("cargo:rustc-link-lib={}", lib);
             }
         }

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -15,9 +15,10 @@
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Web.UI.Interop.h>
 
-#pragma comment(lib, "windowsapp")
+#pragma comment(lib, "windowsapp.lib")
 #pragma comment(lib, "user32.lib")
-#pragma comment(lib, "gdi32")
+#pragma comment(lib, "gdi32.lib")
+#pragma comment(lib, "ole32.lib")
 
 static inline BSTR webview_to_bstr(const char *s) {
   DWORD size = MultiByteToWideChar(CP_UTF8, 0, s, -1, 0, 0);

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -70,9 +70,12 @@ WEBVIEW_API webview_t webview_new(const char* title, const char* url, int width,
 	return wv;
 }
 
-#pragma comment(lib, "user32.lib")
 #pragma comment(lib, "ole32.lib")
+#pragma comment(lib, "comctl32.lib")
 #pragma comment(lib, "oleaut32.lib")
+#pragma comment(lib, "uuid.lib")
+#pragma comment(lib, "gdi32.lib")
+#pragma comment(lib, "user32.lib")
 
 #define WM_WEBVIEW_DISPATCH (WM_APP + 1)
 


### PR DESCRIPTION
Added missing linked libraries to edge backend.
I also kept the pragmas, if someone want to build the backends separately, so they do not have to supply link library flags to msvc.

Fixes #89 