### PR TITLE
Clean up usage of std::string in webview_edge.cpp

### DIFF
--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -196,6 +196,7 @@ JS_Invoke(IDispatch FAR *This, DISPID dispIdMember, REFIID riid, LCID lcid,
           wv->external_invoke_cb(wv, s);
         }
       } else {
+        GlobalFree(s);
         return S_FALSE;
       }
       GlobalFree(s);


### PR DESCRIPTION
Passing strings by value and statements such as `str = str + "foo"` create lots of needless string copies, which means lots of needless allocations. Same with `substr` and `c_str` (in some cases). Also fixed a memory leak (return before free) in the mshtml code.

Using strings this way is a big red flag to experienced C++ devs, because if you get the basics wrong you'll probably end up with at best a slow program and at worst some hard to track down undefined behavior. I'm aware this is a fork from an unmaintained library so I wanted to call attention to the code quality here because I love the potential of this project (came here from tauri) and hope that the C and C++ code will be treated carefully in the future as it's very messy and hard to follow.