### PR TITLE
Allow for graceful Exit

### DIFF
--- a/examples/dialog.rs
+++ b/examples/dialog.rs
@@ -27,7 +27,7 @@ fn main() -> WVResult {
                         .warning("Warning", "You didn't choose a file."),
                 }?,
                 "exit" => {
-                    webview.terminate();
+                    webview.exit();
                 }
                 _ => unimplemented!(),
             };

--- a/examples/graceful_exit.rs
+++ b/examples/graceful_exit.rs
@@ -4,7 +4,7 @@ extern crate web_view;
 use web_view::*;
 
 fn main() {
-    web_view::builder()
+    let res = web_view::builder()
         .title("Minimal webview example")
         .content(Content::Html(include_str!("graceful_exit/index.html")))
         .size(800, 600)

--- a/examples/graceful_exit.rs
+++ b/examples/graceful_exit.rs
@@ -1,4 +1,3 @@
-#![windows_subsystem = "windows"]
 
 extern crate web_view;
 
@@ -15,6 +14,7 @@ fn main() {
         .invoke_handler(invoke_handler)
         .run()
         .unwrap();
+        println!("res: {:?}", res)
 }
 
 fn invoke_handler(wv: &mut WebView<usize>, arg: &str) -> WVResult {

--- a/examples/graceful_exit.rs
+++ b/examples/graceful_exit.rs
@@ -1,0 +1,38 @@
+extern crate web_view;
+
+use web_view::*;
+
+fn main() {
+    println!("starting graceful exit example");
+    let after = web_view::builder()
+        .title("Gracefully exiting webview example")
+        .content(Content::Html(create_html()))
+        .size(800, 600)
+        .resizable(true)
+        .debug(true)
+        .user_data(())
+        .invoke_handler(invoke_handler)
+        .run()
+        .unwrap();
+    println!("after exit: {:?}", after);
+}
+
+fn invoke_handler(wv: &mut WebView<()>, arg: &str) -> WVResult {
+    println!("in handler: {}", arg);
+    if arg == "true" {
+        wv.queue_close()
+    } else {
+        Ok(())
+    }
+}
+
+fn create_html() -> String {
+    "<!DOCTYPE html>
+    <html>
+        <head></head>
+        <body>
+            <button onclick=\"window.external.invoke('true')\">Click me to exit</button>
+        </body>
+    </html>"
+        .to_string()
+}

--- a/examples/graceful_exit.rs
+++ b/examples/graceful_exit.rs
@@ -1,38 +1,32 @@
+#![windows_subsystem = "windows"]
+
 extern crate web_view;
 
 use web_view::*;
 
 fn main() {
-    println!("starting graceful exit example");
-    let after = web_view::builder()
-        .title("Gracefully exiting webview example")
-        .content(Content::Html(create_html()))
+    web_view::builder()
+        .title("Minimal webview example")
+        .content(Content::Html(include_str!("graceful_exit/index.html")))
         .size(800, 600)
         .resizable(true)
         .debug(true)
-        .user_data(())
+        .user_data(0)
         .invoke_handler(invoke_handler)
         .run()
         .unwrap();
-    println!("after exit: {:?}", after);
 }
 
-fn invoke_handler(wv: &mut WebView<()>, arg: &str) -> WVResult {
-    println!("in handler: {}", arg);
-    if arg == "true" {
-        wv.queue_close()
-    } else {
-        Ok(())
+fn invoke_handler(wv: &mut WebView<usize>, arg: &str) -> WVResult {
+    if arg == "init" {
+        wv.eval("init()")?;
+    } else if arg == "update" {
+        *wv.user_data_mut() += 1;
+        let js = format!("setCurrentCount({})", wv.user_data());
+        wv.eval(&js)?;
+    } else if arg == "exit" {
+        println!("exiting!");
+        wv.exit();
     }
-}
-
-fn create_html() -> String {
-    "<!DOCTYPE html>
-    <html>
-        <head></head>
-        <body>
-            <button onclick=\"window.external.invoke('true')\">Click me to exit</button>
-        </body>
-    </html>"
-        .to_string()
+    Ok(())
 }

--- a/examples/graceful_exit.rs
+++ b/examples/graceful_exit.rs
@@ -5,7 +5,7 @@ use web_view::*;
 
 fn main() {
     let res = web_view::builder()
-        .title("Minimal webview example")
+        .title("Graceful Exit Example")
         .content(Content::Html(include_str!("graceful_exit/index.html")))
         .size(800, 600)
         .resizable(true)

--- a/examples/graceful_exit/index.html
+++ b/examples/graceful_exit/index.html
@@ -14,26 +14,28 @@
     <body>
         <h1 id="counter-message" class="preload"></h1>
         <script>
+            var t;
             function init() {
                 var h1 = document.getElementById('counter-message');
                 h1.setAttribute('class', '');
                 setCurrentCount(0);
-                setTimeout(tick, 500);
+                t = setTimeout(tick, 500);
             }
 
             function tick() {
                 window.external.invoke('update');
-                setTimeout(tick, 1000);
+                t = setTimeout(tick, 300);
             }
 
             function setCurrentCount(count) {
                 if (count > 10) {
+                    clearTimeout(t);
                     return window.external.invoke('exit');
                 }
                 var h1 = document.getElementById('counter-message');
                 var rem = 11 - count;
                 var suffix = rem < 2 ? ' second' : ' seconds';
-                h1.innerText = 'Exiting in ' + (11 - count) + suffix;
+                h1.innerText = 'Exiting in ' + rem + suffix;
                 document.body.appendChild(h1);
             }
             external.invoke('init');

--- a/examples/graceful_exit/index.html
+++ b/examples/graceful_exit/index.html
@@ -24,12 +24,11 @@
 
             function tick() {
                 window.external.invoke('update');
-                t = setTimeout(tick, 300);
+                t = setTimeout(tick, 30);
             }
 
             function setCurrentCount(count) {
                 if (count > 10) {
-                    clearTimeout(t);
                     return window.external.invoke('exit');
                 }
                 var h1 = document.getElementById('counter-message');

--- a/examples/graceful_exit/index.html
+++ b/examples/graceful_exit/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            #counter-message.preload {
+                display: none;
+            }
+        </style>
+    </head>
+    <body>
+        <h1 id="counter-message" class="preload"></h1>
+        <script>
+            function init() {
+                let h1 = document.getElementById('counter-message');
+                h1.classList.remove('preload');
+                setCurrentCount(0);
+                setTimeout(tick, 500, 0);
+            }
+            function tick() {
+                window.external.invoke('update');
+                setTimeout(tick, 1000);
+            }
+
+            function setCurrentCount(count) {
+                if (count > 10) {
+                    return window.external.invoke('exit');
+                }
+                let h1 = document.getElementById('counter-message');
+                let rem = 11 - count;
+                let suffix = rem < 2 ? ' second' : ' seconds';
+                h1.innerText = 'Exiting in ' + (11 - count) + suffix;
+                document.body.appendChild(h1);
+            }
+
+            (function() {
+                window.external.invoke('init');
+            })();
+        </script>
+    </body>
+</html>

--- a/examples/graceful_exit/index.html
+++ b/examples/graceful_exit/index.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <style>
             #counter-message.preload {
                 display: none;
+            }
+            #counter-message {
+                display: block;
             }
         </style>
     </head>
@@ -11,11 +15,12 @@
         <h1 id="counter-message" class="preload"></h1>
         <script>
             function init() {
-                let h1 = document.getElementById('counter-message');
-                h1.classList.remove('preload');
+                var h1 = document.getElementById('counter-message');
+                h1.setAttribute('class', '');
                 setCurrentCount(0);
-                setTimeout(tick, 500, 0);
+                setTimeout(tick, 500);
             }
+
             function tick() {
                 window.external.invoke('update');
                 setTimeout(tick, 1000);
@@ -25,16 +30,13 @@
                 if (count > 10) {
                     return window.external.invoke('exit');
                 }
-                let h1 = document.getElementById('counter-message');
-                let rem = 11 - count;
-                let suffix = rem < 2 ? ' second' : ' seconds';
+                var h1 = document.getElementById('counter-message');
+                var rem = 11 - count;
+                var suffix = rem < 2 ? ' second' : ' seconds';
                 h1.innerText = 'Exiting in ' + (11 - count) + suffix;
                 document.body.appendChild(h1);
             }
-
-            (function() {
-                window.external.invoke('init');
-            })();
+            external.invoke('init');
         </script>
     </body>
 </html>

--- a/examples/graceful_exit/index.html
+++ b/examples/graceful_exit/index.html
@@ -24,7 +24,7 @@
 
             function tick() {
                 window.external.invoke('update');
-                t = setTimeout(tick, 30);
+                t = setTimeout(tick, 500);
             }
 
             function setCurrentCount(count) {

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -29,7 +29,7 @@ fn main() {
                     render(webview, *counter)?;
                 }
                 "exit" => {
-                    webview.terminate();
+                    webview.exit();
                 }
                 _ => unimplemented!(),
             };

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,8 +24,6 @@ pub enum Error {
     /// Failure to dispatch a closure to a WebView instance via a handle, likely because the
     /// WebView was dropped.
     Dispatch,
-    /// Not an error, but a graceful shutdown message from the user
-    QueueClose,
     /// An user-specified error occurred. For use inside invoke and dispatch closures.
     Custom(Box<dyn CustomError>),
 }
@@ -60,7 +58,6 @@ impl Display for Error {
                 f,
                 "Closure could not be dispatched. WebView was likely dropped."
             ),
-            Error::QueueClose => write!(f, "request to close window"),
             Error::Custom(e) => write!(f, "Error: {}", e),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     /// Failure to dispatch a closure to a WebView instance via a handle, likely because the
     /// WebView was dropped.
     Dispatch,
+    /// Not an error, but a graceful shutdown message from the user
+    QueueClose,
     /// An user-specified error occurred. For use inside invoke and dispatch closures.
     Custom(Box<dyn CustomError>),
 }
@@ -58,6 +60,7 @@ impl Display for Error {
                 f,
                 "Closure could not be dispatched. WebView was likely dropped."
             ),
+            Error::QueueClose => write!(f, "request to close window"),
             Error::Custom(e) => write!(f, "Error: {}", e),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,12 +423,17 @@ impl<'a, T> WebView<'a, T> {
                     let closure_result = &mut self.user_data_wrapper_mut().result;
                     match closure_result {
                         Ok(_) => Some(Ok(())),
+                        Err(Error::QueueClose) => None,
                         e => Some(mem::replace(e, Ok(()))),
                     }
                 }
                 _ => None,
             }
         }
+    }
+
+    pub fn queue_close(&mut self) -> WVResult<T> {
+        Err(Error::QueueClose)
     }
 
     /// Runs the event loop to completion and returns the user data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,17 +429,12 @@ impl<'a, T> WebView<'a, T> {
                     let closure_result = &mut self.user_data_wrapper_mut().result;
                     match closure_result {
                         Ok(_) => Some(Ok(())),
-                        Err(Error::QueueClose) => None,
                         e => Some(mem::replace(e, Ok(()))),
                     }
                 }
                 _ => None,
             }
         }
-    }
-
-    pub fn queue_close(&mut self) -> WVResult<T> {
-        Err(Error::QueueClose)
     }
 
     /// Runs the event loop to completion and returns the user data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,7 +348,12 @@ impl<'a, T> WebView<'a, T> {
         &mut self.user_data_wrapper_mut().inner
     }
 
-    /// Forces the `WebView` instance to end, without dropping.
+    #[deprecated(note = "Please use exit instead")]
+    pub fn terminate(&mut self) {
+        self.exit();
+    }
+
+    /// Gracefully exits the webview
     pub fn exit(&mut self) {
         unsafe { webview_exit(self.inner) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ mod color;
 mod dialog;
 mod error;
 mod escape;
+
 pub use color::Color;
 pub use dialog::DialogBuilder;
 pub use error::{CustomError, Error, WVResult};
@@ -348,8 +349,8 @@ impl<'a, T> WebView<'a, T> {
     }
 
     /// Forces the `WebView` instance to end, without dropping.
-    pub fn terminate(&mut self) {
-        unsafe { webview_terminate(self.inner) }
+    pub fn exit(&mut self) {
+        unsafe { webview_exit(self.inner) }
     }
 
     /// Executes the provided string as JavaScript code within the `WebView` instance.

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -37,7 +37,6 @@ extern {
 	pub fn webview_free(this: *mut CWebView);
 	pub fn webview_new(title: *const c_char, url: *const c_char, width: c_int, height: c_int, resizable: c_int, debug: c_int, external_invoke_cb: Option<ErasedExternalInvokeFn>, userdata: *mut c_void) -> *mut CWebView;
 	pub fn webview_loop(this: *mut CWebView, blocking: c_int) -> c_int;
-	pub fn webview_terminate(this: *mut CWebView);
 	pub fn webview_exit(this: *mut CWebView);
 	pub fn webview_get_user_data(this: *mut CWebView) -> *mut c_void;
 	pub fn webview_dispatch(this: *mut CWebView, f: Option<ErasedDispatchFn>, arg: *mut c_void);

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -40,7 +40,6 @@ WEBVIEW_API void webview_dialog(webview_t w,
                                 char *result, size_t resultsz);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
                                   void *arg);
-WEBVIEW_API void webview_terminate(webview_t w);
 WEBVIEW_API void webview_exit(webview_t w);
 WEBVIEW_API void webview_debug(const char *format, ...);
 WEBVIEW_API void webview_print_log(const char *s);

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -637,9 +637,8 @@ WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
 
 WEBVIEW_API void webview_exit(webview_t w) {
   struct cocoa_webview* wv = (struct cocoa_webview*)w;
-  id app = objc_msgSend((id)objc_getClass("NSApplication"),
-                        sel_registerName("sharedApplication"));
-  objc_msgSend(app, sel_registerName("terminate:"), app);
+  objc_msgSend(wv->priv.window,
+                        sel_registerName("performClose:"), wv->priv.window);
 }
 
 WEBVIEW_API void webview_print_log(const char *s) { printf("%s\n", s); }

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -498,12 +498,12 @@ WEBVIEW_API int webview_loop(webview_t w, int blocking) {
                                       sel_registerName("distantFuture"))
                        : objc_msgSend((id)objc_getClass("NSDate"),
                                       sel_registerName("distantPast")));
-  printf("%u getting event\n", loopcount);
   id app = objc_msgSend((id)objc_getClass("NSApplication"),
                    sel_registerName("sharedApplication"));
   id wins = objc_msgSend(app, sel_registerName("windows"));
-  uint win_ct = objc_msgSend(wins, sel_registerName("containsObject:"), wv->priv.window);
-  printf("%u app windows %u\n", win_ct);
+  uint win_ct = objc_msgSend(wins, sel_registerName("count"));
+  printf("%u app windows %u\n", loopcount, win_ct);
+  printf("%u getting event\n", loopcount);
   id event = objc_msgSend(
       app,
       sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -88,9 +88,9 @@ static id create_menu_item(id title, const char *action, const char *key) {
 }
 
 static void webview_window_will_close(id self, SEL cmd, id notification) {
-  struct cocoa_webview *w =
+  struct cocoa_webview* wv =
       (struct cocoa_webview *)objc_getAssociatedObject(self, "webview");
-  webview_terminate(w);
+  wv->priv.should_exit = 1;
 }
 
 static void webview_external_invoke(id self, SEL cmd, id contentController,
@@ -633,11 +633,6 @@ WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
   context->arg = arg;
   context->fn = fn;
   dispatch_async_f(dispatch_get_main_queue(), context, webview_dispatch_cb);
-}
-
-WEBVIEW_API void webview_terminate(webview_t w) {
-  struct cocoa_webview* wv = (struct cocoa_webview*)w;
-  wv->priv.should_exit = 1;
 }
 
 WEBVIEW_API void webview_exit(webview_t w) {

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -4,6 +4,78 @@
 #include <CoreGraphics/CoreGraphics.h>
 #include <limits.h>
 
+static char * debug_event_string(uint event_type) {
+  switch (event_type) {
+    case 1: 
+      return "NSEventTypeLeftMouseDown";
+    case 2: 
+      return "NSEventTypeLeftMouseUp";
+    case 3: 
+      return "NSEventTypeRightMouseDown";
+    case 4: 
+      return "NSEventTypeRightMouseUp";
+    case 5: 
+      return "NSEventTypeMouseMoved";
+    case 6: 
+      return "NSEventTypeLeftMouseDragged";
+    case 7: 
+      return "NSEventTypeRightMouseDragged";
+    case 8: 
+      return "NSEventTypeMouseEntered";
+    case 9: 
+      return "NSEventTypeMouseExited";
+    case 10: 
+      return "NSEventTypeKeyDown";
+    case 11: 
+      return "NSEventTypeKeyUp";
+    case 12: 
+      return "NSEventTypeFlagsChanged";
+    case 13: 
+      return "NSEventTypeAppKitDefined";
+    case 14: 
+      return "NSEventTypeSystemDefined";
+    case 15: 
+      return "NSEventTypeApplicationDefined";
+    case 16: 
+      return "NSEventTypePeriodic";
+    case 17: 
+      return "NSEventTypeCursorUpdate";
+    case 18: 
+      return "NSEventTypeScrollWheel";
+    case 19: 
+      return "NSEventTypeTabletPoint";
+    case 20: 
+      return "NSEventTypeTabletProximity";
+    case 21: 
+      return "NSEventTypeOtherMouseDown";
+    case 22: 
+      return "NSEventTypeOtherMouseUp";
+    case 23: 
+      return "NSEventTypeOtherMouseDragged";
+    case 24: 
+      return "NSEventTypeGesture";
+    case 25: 
+      return "NSEventTypeMagnify";
+    case 26: 
+      return "NSEventTypeSwipe";
+    case 27: 
+      return "NSEventTypeRotate";
+    case 28: 
+      return "NSEventTypeBeginGesture";
+    case 29: 
+      return "NSEventTypeEndGesture";
+    case 30: 
+      return "NSEventTypeSmartMagnify";
+    case 31: 
+      return "NSEventTypePressure";
+    case 32: 
+      return "NSEventTypeDirectTouch";
+    case 33: 
+      return "NSEventTypeQuickLook";
+    default:
+      return "Unknown";
+  }
+}
 struct webview_priv {
   id pool;
   id window;
@@ -512,15 +584,16 @@ WEBVIEW_API int webview_loop(webview_t w, int blocking) {
                    sel_registerName("stringWithUTF8String:"),
                    "kCFRunLoopDefaultMode"),
       true);
-  printf("%u received event %u\n", loopcount, objc_msgSend(event, sel_registerName("type")));
+  char *event_str = debug_event_string(objc_msgSend(event, sel_registerName("type")));
+  printf("%u received event %s\n", loopcount, event_str);
   printf("subtype %u\n", objc_msgSend(event, sel_registerName("subtype")));
   
   if (event) {
-    printf("%d sending event %u\n", loopcount, objc_msgSend(event, sel_registerName("type")));
+    printf("%d sending event %s\n", loopcount,  event_str);
     objc_msgSend(objc_msgSend((id)objc_getClass("NSApplication"),
                               sel_registerName("sharedApplication")),
                  sel_registerName("sendEvent:"), event);
-    printf("%d sent event %u\n", loopcount, objc_msgSend(event, sel_registerName("type")));
+    printf("%d sent event %s\n", loopcount, event_str);
   }
   printf("exiting again %u\n", wv->priv.should_exit);
   return wv->priv.should_exit;

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -89,7 +89,7 @@ static id create_menu_item(id title, const char *action, const char *key) {
 }
 
 static void webview_window_will_close(id self, SEL cmd, id notification) {
-  struct cocoa_webview* wv =
+  struct cocoa_webview *wv =
       (struct cocoa_webview *)objc_getAssociatedObject(self, "webview");
   wv->priv.should_exit = 1;
   // To trigger the event loop to move forward one step
@@ -104,12 +104,6 @@ static void webview_window_will_close(id self, SEL cmd, id notification) {
                         sel_registerName("sharedApplication"));
   objc_msgSend(app, sel_registerName("postEvent:atStart:"), event, objc_msgSend((id)objc_getClass("NSDate"),
                                       sel_registerName("distantPast")));
-}
-
-static BOOL webview_window_should_close(id self, SEL cmd, id notification) {
-  struct cocoa_webview* wv =
-      (struct cocoa_webview *)objc_getAssociatedObject(self, "webview");
-  return (BOOL)wv->priv.should_exit;
 }
 
 static void webview_external_invoke(id self, SEL cmd, id contentController,
@@ -322,8 +316,6 @@ WEBVIEW_API int webview_init(webview_t w) {
   class_addProtocol(__NSWindowDelegate, objc_getProtocol("NSWindowDelegate"));
   class_replaceMethod(__NSWindowDelegate, sel_registerName("windowWillClose:"),
                       (IMP)webview_window_will_close, "v@:@");
-  class_replaceMethod(__NSWindowDelegate, sel_registerName("windowshouldClose:"),
-                      (IMP)webview_window_should_close, "v@:@");
   objc_registerClassPair(__NSWindowDelegate);
 
   wv->priv.windowDelegate =
@@ -331,7 +323,6 @@ WEBVIEW_API int webview_init(webview_t w) {
 
   objc_setAssociatedObject(wv->priv.windowDelegate, "webview", (id)(w),
                            OBJC_ASSOCIATION_ASSIGN);
-  objc_msgSend(wv->priv.windowDelegate, sel_registerName("autorelease"));
 
   id nsTitle =
       objc_msgSend((id)objc_getClass("NSString"),
@@ -356,7 +347,6 @@ WEBVIEW_API int webview_init(webview_t w) {
   objc_msgSend(wv->priv.window, sel_registerName("setDelegate:"),
                wv->priv.windowDelegate);
   objc_msgSend(wv->priv.window, sel_registerName("center"));
-  objc_msgSend(wv->priv.window, sel_registerName("setReleasedWhenClosed:"), YES);
 
   Class __WKUIDelegate =
       objc_allocateClassPair(objc_getClass("NSObject"), "__WKUIDelegate", 0);
@@ -396,9 +386,6 @@ WEBVIEW_API int webview_init(webview_t w) {
   objc_msgSend(wv->priv.webview, sel_registerName("setUIDelegate:"), uiDel);
   objc_msgSend(wv->priv.webview, sel_registerName("setNavigationDelegate:"),
                navDel);
-  objc_msgSend(wv->priv.webview, sel_registerName("autorelease"));
-  objc_msgSend(uiDel, sel_registerName("autorelease"));
-  objc_msgSend(navDel, sel_registerName("autorelease"));
   
   id nsURL = objc_msgSend((id)objc_getClass("NSURL"),
                           sel_registerName("URLWithString:"),
@@ -491,8 +478,6 @@ WEBVIEW_API int webview_loop(webview_t w, int blocking) {
                                       sel_registerName("distantPast")));
   id app = objc_msgSend((id)objc_getClass("NSApplication"),
                    sel_registerName("sharedApplication"));
-  id wins = objc_msgSend(app, sel_registerName("windows"));
-  uint win_ct = objc_msgSend(wins, sel_registerName("count"));
   id event = objc_msgSend(
       app,
       sel_registerName("nextEventMatchingMask:untilDate:inMode:dequeue:"),

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -147,7 +147,6 @@ public:
         return 0;
     }
 
-    void terminate() { PostQuitMessage(0); }
     void dispatch(dispatch_fn_t f)
     {
         PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));
@@ -242,8 +241,7 @@ LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         DestroyWindow(hwnd);
         break;
     case WM_DESTROY:
-        DestroyWindow(w->m_window);
-        PostQuitMessage(0);
+        w->quit();
         break;
     default:
         return DefWindowProc(hwnd, msg, wp, lp);
@@ -313,8 +311,7 @@ public:
             L"eval", single_threaded_vector<hstring>({ winrt::to_hstring(js) }));
     }
 
-    void terminate() {
-        browser_window::terminate();
+    void exit() {
         m_webview.Close();
     }
 
@@ -583,11 +580,6 @@ WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
                                   void *arg)
 {
     static_cast<webview::webview*>(w)->dispatch([=]() { fn(w, arg); });
-}
-
-WEBVIEW_API void webview_terminate(webview_t w)
-{
-    static_cast<webview::webview*>(w)->terminate();
 }
 
 WEBVIEW_API void webview_exit(webview_t w)

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -146,7 +146,7 @@ public:
 
         return 0;
     }
-
+    void exit() { PostQuitMessage(0); }
     void dispatch(dispatch_fn_t f)
     {
         PostThreadMessage(m_main_thread, WM_APP, 0, (LPARAM) new dispatch_fn_t(f));

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -594,7 +594,6 @@ WEBVIEW_API void webview_exit(webview_t w)
 {
     webview::webview* wv = static_cast<webview::webview*>(w);
     DestroyWindow(wv->m_window);
-    OleUninitialize();
 }
 
 WEBVIEW_API void webview_debug(const char *format, ...)

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -242,7 +242,8 @@ LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         DestroyWindow(hwnd);
         break;
     case WM_DESTROY:
-        w->terminate();
+        DestroyWindow(w->m_window);
+        PostQuitMessage(0);
         break;
     default:
         return DefWindowProc(hwnd, msg, wp, lp);
@@ -591,7 +592,9 @@ WEBVIEW_API void webview_terminate(webview_t w)
 
 WEBVIEW_API void webview_exit(webview_t w)
 {
-    webview_terminate(w);
+    webview::webview* wv = static_cast<webview::webview*>(w);
+    DestroyWindow(wv->m_window);
+    OleUninitialize();
 }
 
 WEBVIEW_API void webview_debug(const char *format, ...)

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -241,7 +241,7 @@ LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         DestroyWindow(hwnd);
         break;
     case WM_DESTROY:
-        w->quit();
+        w->exit();
         break;
     default:
         return DefWindowProc(hwnd, msg, wp, lp);

--- a/webview-sys/webview_gtk.c
+++ b/webview-sys/webview_gtk.c
@@ -83,7 +83,7 @@ static void webview_load_changed_cb(WebKitWebView *webview,
 
 static void webview_destroy_cb(GtkWidget *widget, gpointer arg) {
   (void)widget;
-  webview_terminate((webview_t)arg);
+  webview_exit((webview_t)arg);
 }
 
 static gboolean webview_context_menu_cb(WebKitWebView *webview,

--- a/webview-sys/webview_gtk.c
+++ b/webview-sys/webview_gtk.c
@@ -298,12 +298,10 @@ WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
   g_async_queue_unlock(wv->priv.queue);
 }
 
-WEBVIEW_API void webview_terminate(webview_t w) {
+WEBVIEW_API void webview_exit(webview_t w) { 
   struct gtk_webview *wv = (struct webview *)w;
   wv->priv.should_exit = 1;
 }
-
-WEBVIEW_API void webview_exit(webview_t w) { (void)w; }
 WEBVIEW_API void webview_print_log(const char *s) {
   fprintf(stderr, "%s\n", s);
 }


### PR DESCRIPTION
This is one possible option for allowing the invoke_handler to gracefully request a shutdown of the window to address #105.

This was the quickest thing I could think of but I am not sure it is really the best approach. One thing that might be better would be to put a new flag on `UserData` to indicate that `run` should exit