### PR TITLE
mshtml, edge: speed up `Content::Html`

### DIFF
--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -125,6 +125,27 @@ static inline const char *webview_check_url(const char *url) {
   return url;
 }
 
+// Convert ASCII hex digit to a nibble (four bits, 0 - 15).
+//
+// Use unsigned to avoid signed overflow UB.
+static inline unsigned char hex2nibble(unsigned char c) {
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  } else if (c >= 'a' && c <= 'f') {
+    return 10 + (c - 'a');
+  } else if (c >= 'A' && c <= 'F') {
+    return 10 + (c - 'A');
+  }
+  return 0;
+}
+
+// Convert ASCII hex string (two characters) to byte.
+//
+// E.g., "0B" => 0x0B, "af" => 0xAF.
+static inline char hex2char(const char* p) {
+  return hex2nibble(p[0]) * 16 + hex2nibble(p[1]);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -41,9 +41,7 @@ inline std::string url_decode(const char *s)
     size_t length = strlen(s);
     for (unsigned int i = 0; i < length; i++) {
         if (s[i] == '%') {
-            int n;
-            sscanf(s + i + 1, "%2x", &n);
-            decoded.push_back(static_cast<char>(n));
+            decoded.push_back(hex2char(s + i + 1));
             i = i + 2;
         } else if (s[i] == '+') {
             decoded.push_back(' ');

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -729,7 +729,7 @@ static int DisplayHTMLPage(struct mshtml_webview *wv) {
     for (const char *p = webview_url + strlen(WEBVIEW_DATA_URL_PREFIX); *q = *p;
          p++, q++) {
       if (*q == '%' && *(p + 1) && *(p + 2)) {
-        sscanf(p + 1, "%02x", q);
+        *q = hex2char(p + 1);
         p = p + 2;
       }
     }


### PR DESCRIPTION
Previously `sscanf` is used in decoding the url-encoded html document.
But `sscanf` is quite expensive. Loading a larger document (~800KiB) has
a noticeable delay.

And mshtml is giving the third argument to `sscanf` a `char*` when it
should be an `int*`. It is very problematic.

This commit replaces them with our own hex decoding function.