### PR TITLE
windows: enable DPI awareness

### DIFF
--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -73,7 +73,7 @@ private:
                 GetProcAddress(lib_user32, "SetThreadDpiAwarenessContext")
             );
             if (
-                fnSetThreadDpiAwarenessContext
+                fn_set_thread_dpi_awareness_context
                 && fn_set_thread_dpi_awareness_context(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
             ) {
                 return true;

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -903,6 +903,7 @@ int webview_init(struct mshtml_webview *wv) {
   if (oleInitCode != S_OK && oleInitCode != S_FALSE) {
     return -1;
   }
+  EnableDpiAwareness();
   ZeroMemory(&wc, sizeof(WNDCLASSEX));
   wc.cbSize = sizeof(WNDCLASSEX);
   wc.hInstance = hInstance;
@@ -947,7 +948,6 @@ int webview_init(struct mshtml_webview *wv) {
     SetWindowLongPtr(wv->priv.hwnd, GWL_STYLE, style);
   }
   DisplayHTMLPage(wv);
-  EnableDpiAwareness();
 
   SetWindowText(wv->priv.hwnd, wv->title);
   ShowWindow(wv->priv.hwnd, SW_SHOWDEFAULT);

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -114,7 +114,7 @@ typedef struct {
   _IServiceProviderEx provider;
 } _IOleClientSiteEx;
 
-typedef BOOL (*SetThreadDpiAwareness)(int);
+typedef BOOL (*SetThreadDpiAwareness)(DPI_AWARENESS_CONTEXT);
 typedef BOOL (*SetProcessDpiAwareness)(int);
 
 #ifdef __cplusplus

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -114,6 +114,9 @@ typedef struct {
   _IServiceProviderEx provider;
 } _IOleClientSiteEx;
 
+typedef BOOL (*SetThreadDpiAwareness)(int);
+typedef BOOL (*SetProcessDpiAwareness)(int);
+
 #ifdef __cplusplus
 #define iid_ref(x) &(x)
 #define iid_unref(x) *(x)
@@ -213,6 +216,39 @@ static IDispatchVtbl ExternalDispatchTable = {
     JS_QueryInterface, JS_AddRef,        JS_Release, JS_GetTypeInfoCount,
     JS_GetTypeInfo,    JS_GetIDsOfNames, JS_Invoke};
 
+
+static HRESULT EnableDpiAwareness() {
+    auto libUser32 = GetModuleHandleW(L"user32.dll");
+    if (libUser32) {
+        SetThreadDpiAwareness set_thread_dpi_awareness =
+            (SetThreadDpiAwareness) GetProcAddress(libUser32, "SetThreadDpiAwarenessContext");
+        if(set_thread_dpi_awareness == NULL) {
+            return E_NOINTERFACE;
+        } else {
+            BOOL thread_awareness_retval = set_thread_dpi_awareness(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+            if(!thread_awareness_retval) {
+                return E_NOINTERFACE;
+            }
+        }
+    }
+    auto lib_shcore = LoadLibraryW(L"shcore.dll");
+    if (!lib_shcore) {
+        return E_NOINTERFACE;
+    }
+    SetProcessDpiAwareness set_process_dpi_awareness =
+        (SetProcessDpiAwareness) GetProcAddress(lib_shcore, "SetProcessDpiAwareness");
+    if(set_process_dpi_awareness == NULL) {
+        return E_NOINTERFACE;
+    } else {
+        BOOL process_awareness_retval = set_process_dpi_awareness(2);
+        if(!process_awareness_retval) {
+            FreeLibrary(lib_shcore);
+            return E_NOINTERFACE;
+        }
+    }
+    FreeLibrary(lib_shcore);
+    return S_OK;
+}
 static ULONG STDMETHODCALLTYPE Site_AddRef(IOleClientSite FAR *This) {
   return 1;
 }
@@ -424,7 +460,7 @@ static HRESULT STDMETHODCALLTYPE UI_ShowContextMenu(
 static HRESULT STDMETHODCALLTYPE
 UI_GetHostInfo(IDocHostUIHandler FAR *This, DOCHOSTUIINFO __RPC_FAR *pInfo) {
   pInfo->cbSize = sizeof(DOCHOSTUIINFO);
-  pInfo->dwFlags = DOCHOSTUIFLAG_NO3DBORDER;
+  pInfo->dwFlags = DOCHOSTUIFLAG_NO3DBORDER | DOCHOSTUIFLAG_DPI_AWARE;
   pInfo->dwDoubleClick = DOCHOSTUIDBLCLK_DEFAULT;
   return S_OK;
 }
@@ -612,6 +648,7 @@ static void UnEmbedBrowserObject(webview_t w) {
   }
 }
 
+
 static int EmbedBrowserObject(webview_t w) {
   struct mshtml_webview* wv = (struct mshtml_webview*)w;
   RECT rect;
@@ -790,6 +827,23 @@ static LRESULT CALLBACK wndproc(HWND hwnd, UINT uMsg, WPARAM wParam,
     }
     return TRUE;
   }
+  case WM_DPICHANGED: {
+    RECT rect;
+    GetClientRect(hwnd, &rect);
+    auto x = rect.left;
+    auto y = rect.top;
+    auto w = rect.right - x;
+    auto h = rect.bottom - y;
+    SetWindowPos(hwnd, NULL, x, y, w, h, SWP_NOZORDER);
+    auto monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    MONITORINFOEXW mi;
+    mi.cbSize = sizeof(MONITORINFOEXW);
+    GetMonitorInfoW(monitor, &mi);
+    auto scale = LOWORD(wParam) / (float)USER_DEFAULT_SCREEN_DPI;
+    auto xres = mi.rcMonitor.right - mi.rcMonitor.left;
+    auto yres = mi.rcMonitor.bottom - mi.rcMonitor.top;
+    return TRUE;
+  }
   case WM_WEBVIEW_DISPATCH: {
     webview_dispatch_fn f = (webview_dispatch_fn)wParam;
     void *arg = (void *)lParam;
@@ -893,6 +947,7 @@ int webview_init(struct mshtml_webview *wv) {
     SetWindowLongPtr(wv->priv.hwnd, GWL_STYLE, style);
   }
   DisplayHTMLPage(wv);
+  EnableDpiAwareness();
 
   SetWindowText(wv->priv.hwnd, wv->title);
   ShowWindow(wv->priv.hwnd, SW_SHOWDEFAULT);

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -218,7 +218,7 @@ static IDispatchVtbl ExternalDispatchTable = {
 
 
 static HRESULT EnableDpiAwareness() {
-    auto libUser32 = GetModuleHandleW(L"user32.dll");
+    HMODULE libUser32 = GetModuleHandleW(L"user32.dll");
     if (libUser32) {
         SetThreadDpiAwareness set_thread_dpi_awareness =
             (SetThreadDpiAwareness) GetProcAddress(libUser32, "SetThreadDpiAwarenessContext");
@@ -231,7 +231,7 @@ static HRESULT EnableDpiAwareness() {
             }
         }
     }
-    auto lib_shcore = LoadLibraryW(L"shcore.dll");
+    HMODULE lib_shcore = LoadLibraryW(L"shcore.dll");
     if (!lib_shcore) {
         return E_NOINTERFACE;
     }


### PR DESCRIPTION
#117 is a bit inactive so I finished it myself.

Close #99.

It works but for mshtml I could not figure out how to make the browser correctly handle DPI changes. So mshtml uses *system DPI awareness* for now.

(FWIW, using the WebBrowser control in WPF, and `FEATURE_96DPI_PIXEL`, it correctly handles DPI changes. So it should be possible.)