### PR TITLE
Fix deadlock during shutdown

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,7 +458,7 @@ impl<'a, T> WebView<'a, T> {
     }
 
     unsafe fn _into_inner(&mut self) -> T {
-        let _lock = self
+        let lock = self
             .user_data_wrapper()
             .live
             .write()
@@ -468,6 +468,7 @@ impl<'a, T> WebView<'a, T> {
         webview_exit(self.inner);
         webview_free(self.inner);
         let user_data = *Box::from_raw(user_data_ptr);
+        std::mem::drop(lock);
         user_data.inner
     }
 }


### PR DESCRIPTION
On Ubuntu 16.04 with libwebkit2gtk-4.0, I had a deadlock during the shutdown (reproducible with any example).

For what I understand when leaving the function `user_data` is destroyed first, then `_lock` is destroyed but the underlying `RWLock<>` has already been destroyed (it is part of `UserData<>`). As a result it deadlocks.