### PR TITLE
Implement minimize method, for frameless windows, for edge and gtk backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ For more usage info please check out the [examples](https://github.com/Boscop/we
 - [SOUNDSENSE-RS](https://github.com/prixt/soundsense-rs) - Sound-engine tool for Dwarf Fortress
 - [Tauri](https://github.com/tauri-apps/tauri) - Bringing security into webstack GUIs, with strong support for your favorite JS frameworks
 - [WV Linewise](https://github.com/forbesmyester/wv-linewise) - Add your own interactive HTML/CSS/JS in the middle of your UNIX pipelines
+- [Bloop](https://github.com/Blakeinstein/Bloop) - A light weight aesthetic scratchpad for developers.
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,8 +437,14 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_fullscreen(self.inner.unwrap(), fullscreen as _) };
     }
 
+    /// Toggle window maximized
     pub fn set_maximized(&mut self, maximize: bool) {
         unsafe { webview_set_maximized(self.inner.unwrap(), maximize as _) };
+    }
+
+    /// Minimizes window
+    pub fn set_minimized(&mut self) {
+        unsafe { webview_set_minimized(self.inner.unwrap()) };
     }
 
     /// Returns a builder for opening a new dialog window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,8 +443,8 @@ impl<'a, T> WebView<'a, T> {
     }
 
     /// Minimizes window
-    pub fn set_minimized(&mut self) {
-        unsafe { webview_set_minimized(self.inner.unwrap()) };
+    pub fn set_minimized(&mut self, minimize: bool) {
+        unsafe { webview_set_minimized(self.inner.unwrap(), minimize as _) };
     }
 
     /// Returns a builder for opening a new dialog window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,10 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_fullscreen(self.inner.unwrap(), fullscreen as _) };
     }
 
+    pub fn set_maximized(&mut self, maximize: bool) {
+        unsafe { webview_set_maximized(self.inner.unwrap(), maximize as _) };
+    }
+
     /// Returns a builder for opening a new dialog window.
     #[deprecated(
         note = "Please use crates like 'tinyfiledialogs' for dialog handling, see example in examples/dialog.rs"

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -59,7 +59,7 @@ unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_in
 
 #[no_mangle]
 unsafe extern "C" fn webview_set_minimized(webview: *mut WebView) {
-    gtk_window_minimized(mem::transmute((*webview).window));
+    gtk_window_iconify(mem::transmute((*webview).window));
 }
 
 #[no_mangle]

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -49,6 +49,14 @@ unsafe extern "C" fn webview_set_fullscreen(webview: *mut WebView, fullscreen: c
     }
 }
 
+unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_int) {
+    if maximize > 0 {
+        gtk_window_maximize(mem::transmute((*webview).window));
+    } else {
+        gtk_window_unmaximize(mem::transmute((*webview).window));
+    }
+}
+
 #[no_mangle]
 unsafe extern "C" fn webview_new(
     title: *const c_char,

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -58,6 +58,11 @@ unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_in
 }
 
 #[no_mangle]
+unsafe extern "C" fn webview_set_minimized(webview: *mut WebView) {
+    gtk_window_minimized(mem::transmute((*webview).window));
+}
+
+#[no_mangle]
 unsafe extern "C" fn webview_new(
     title: *const c_char,
     url: *const c_char,

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -63,11 +63,6 @@ unsafe extern "C" fn webview_set_minimized(webview: *mut WebView) {
 }
 
 #[no_mangle]
-unsafe extern "C" fn webview_set_minimized(webview: *mut WebView) {
-    gtk_window_iconify(mem::transmute((*webview).window));
-}
-
-#[no_mangle]
 unsafe extern "C" fn webview_new(
     title: *const c_char,
     url: *const c_char,

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -50,6 +50,9 @@ unsafe extern "C" fn webview_set_fullscreen(webview: *mut WebView, fullscreen: c
 }
 
 unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_int) {
+    if maximize == gtk_window_is_maximized(mem::transmute((*webview).window)) {
+        return;
+    }
     if maximize > 0 {
         gtk_window_maximize(mem::transmute((*webview).window));
     } else {
@@ -58,8 +61,15 @@ unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_in
 }
 
 #[no_mangle]
-unsafe extern "C" fn webview_set_minimized(webview: *mut WebView) {
-    gtk_window_iconify(mem::transmute((*webview).window));
+unsafe extern "C" fn webview_set_minimized(webview: *mut WebView, minimize: c_int) {
+    if minimize == gtk_window_is_active(mem::transmute((*webview).window)) {
+        return;
+    }
+    if minimize > 0 {
+        gtk_window_iconify(mem::transmute((*webview).window));
+    } else {
+        gtk_window_deiconify(mem::transmute((*webview).window));
+    }
 }
 
 #[no_mangle]

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -36,6 +36,6 @@ extern "C" {
     pub fn webview_set_title(this: *mut CWebView, title: *const c_char);
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
     pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
-    pub fn webview_set_minimized(this: *mut CWebView);
+    pub fn webview_set_minimized(this: *mut CWebView, minimize: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -35,5 +35,6 @@ extern "C" {
     pub fn webview_eval(this: *mut CWebView, js: *const c_char) -> c_int;
     pub fn webview_set_title(this: *mut CWebView, title: *const c_char);
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
+    pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -36,5 +36,6 @@ extern "C" {
     pub fn webview_set_title(this: *mut CWebView, title: *const c_char);
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
     pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
+    pub fn webview_set_minimized(this: *mut CWebView);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -26,6 +26,7 @@ WEBVIEW_API int webview_eval(webview_t w, const char *js);
 WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
+WEBVIEW_API void webview_set_minimized(webview_t w);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -25,6 +25,7 @@ WEBVIEW_API int webview_loop(webview_t w, int blocking);
 WEBVIEW_API int webview_eval(webview_t w, const char *js);
 WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
+WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -26,7 +26,7 @@ WEBVIEW_API int webview_eval(webview_t w, const char *js);
 WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
-WEBVIEW_API void webview_set_minimized(webview_t w);
+WEBVIEW_API void webview_set_minimized(webview_t w, int minimize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -371,7 +371,7 @@ WEBVIEW_API int webview_init(webview_t w) {
   CGRect r = CGRectMake(0, 0, wv->width, wv->height);
   unsigned int style;
   if (wv->frameless) {
-    style = NSWindowStyleMaskBorderless;
+    style = NSWindowStyleMaskBorderless | NSWindowStyleMaskMiniaturizable;
   } else {
     style = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
                         NSWindowStyleMaskMiniaturizable;
@@ -579,6 +579,11 @@ WEBVIEW_API void webview_set_maximized(webview_t w, int maximize) {
   if (windowZoomStatus != maximize) {
     objc_msgSend(wv->priv.window, sel_registerName("zoom:"), NULL);
   }
+}
+
+WEBVIEW_API void webview_set_minimized(webview_t w) {
+  struct cocoa_webview* wv = (struct cocoa_webview*)w;
+  objc_msgSend(wv->priv.window, sel_registerName("miniaturize:"), NULL);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -572,6 +572,15 @@ WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen) {
   }
 }
 
+WEBVIEW_API void webview_set_maximized(webview_t w, int maximize) {
+  struct cocoa_webview* wv = (struct cocoa_webview*)w;
+  bool windowZoomStatus = (bool)objc_msgSend(
+      wv->priv.window, sel_registerName("isZoomed"));
+  if (windowZoomStatus != maximize) {
+    objc_msgSend(wv->priv.window, sel_registerName("zoom:"), NULL);
+  }
+}
+
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a) {
   struct cocoa_webview* wv = (struct cocoa_webview*)w;

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -581,9 +581,19 @@ WEBVIEW_API void webview_set_maximized(webview_t w, int maximize) {
   }
 }
 
-WEBVIEW_API void webview_set_minimized(webview_t w) {
+WEBVIEW_API void webview_set_minimized(webview_t w, int minimize) {
   struct cocoa_webview* wv = (struct cocoa_webview*)w;
-  objc_msgSend(wv->priv.window, sel_registerName("miniaturize:"), NULL);
+  bool windowMinimizeStatus = (bool)objc_msgSend(
+      wv->priv.window, sel_registerName("isMinimized"));
+  if (minimize == windowMinimizeStatus) {
+    return;
+  }
+  if (minimize) {
+    objc_msgSend(wv->priv.window, sel_registerName("miniaturize:"), NULL);
+  } else {
+    objc_msgSend(wv->priv.window, sel_registerName("deminiaturize:"), NULL);
+  }
+  
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -277,34 +277,43 @@ public:
                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
         }
     }
-    void set_minimized()
-    {
-        ShowWindow(this->m_window, SW_SHOWMINIMIZED);
+    void set_minimized(bool minimize)
+    {   
+        bool is_minimized = IsIconic(this->m_window);
+        if (is_minimized == minimize) {
+            set_maximized(true);
+            return;
+        }
+        if (minimize)
+            ShowWindow(this->m_window, SW_MINIMIZE);
+        else
+            ShowWindow(this->m_window, SW_RESTORE);
     }
 
     void set_maximized(bool maximize)
     {
-
-        if (this->is_maximized == maximize) {
+        bool is_maximized = IsZoomed(this->m_window);
+        if (is_maximized == maximize) {
             return;
         }
-        if (!this->is_maximized) {
+        if (!is_maximized) {
             GetWindowRect(this->m_window, &this->saved_rect);
         }
-        this->is_maximized = !!maximize;
         if (maximize) {
             RECT r;
 
             SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0);
-            SetWindowPos(this->m_window, NULL, r.left, r.top, r.right - r.left,
+            ShowWindow(this->m_window, SW_MAXIMIZE);
+            SetWindowPos(this->m_window, NULL, 0, 0, r.right - r.left,
                         r.bottom - r.top,
-                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                        SWP_SHOWWINDOW);
         } else {
+            ShowWindow(this->m_window, SW_RESTORE);
             SetWindowPos(this->m_window, NULL, this->saved_rect.left,
                         this->saved_rect.top,
                         this->saved_rect.right - this->saved_rect.left,
                         this->saved_rect.bottom - this->saved_rect.top,
-                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+                        SWP_SHOWWINDOW);
         }
     }
 
@@ -495,9 +504,9 @@ WEBVIEW_API void webview_set_maximized(webview_t w, int maximize)
     static_cast<webview::webview*>(w)->set_maximized(maximize);
 }
 
-WEBVIEW_API void webview_set_minimized(webview_t w)
+WEBVIEW_API void webview_set_minimized(webview_t w, int minimize)
 {
-    static_cast<webview::webview*>(w)->set_minimized();
+    static_cast<webview::webview*>(w)->set_minimized(minimize);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -277,6 +277,10 @@ public:
                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
         }
     }
+    void set_minimized()
+    {
+        ShowWindow(this->m_window, SW_SHOWMINIMIZED);
+    }
 
     void set_maximized(bool maximize)
     {
@@ -489,6 +493,11 @@ WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen)
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize)
 {
     static_cast<webview::webview*>(w)->set_maximized(maximize);
+}
+
+WEBVIEW_API void webview_set_minimized(webview_t w)
+{
+    static_cast<webview::webview*>(w)->set_minimized();
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -278,6 +278,32 @@ public:
         }
     }
 
+    void set_maximized(bool maximize)
+    {
+
+        if (this->is_maximized == maximize) {
+            return;
+        }
+        if (!this->is_maximized) {
+            GetWindowRect(this->m_window, &this->saved_rect);
+        }
+        this->is_maximized = !!maximize;
+        if (maximize) {
+            RECT r;
+
+            SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0);
+            SetWindowPos(this->m_window, NULL, r.left, r.top, r.right - r.left,
+                        r.bottom - r.top,
+                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        } else {
+            SetWindowPos(this->m_window, NULL, this->saved_rect.left,
+                        this->saved_rect.top,
+                        this->saved_rect.right - this->saved_rect.left,
+                        this->saved_rect.bottom - this->saved_rect.top,
+                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        }
+    }
+
     void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
 
@@ -292,6 +318,7 @@ public:
     msg_cb_t m_cb;
 
     bool is_fullscreen = false;
+    bool is_maximized = false;
     DWORD saved_style = 0;
     DWORD saved_ex_style = 0;
     RECT saved_rect;
@@ -457,6 +484,11 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title)
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen)
 {
     static_cast<webview::webview*>(w)->set_fullscreen(fullscreen);
+}
+
+WEBVIEW_API void webview_set_maximized(webview_t w, int maximize)
+{
+    static_cast<webview::webview*>(w)->set_maximized(maximize);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1134,6 +1134,11 @@ WEBVIEW_API void webview_set_maximized(webview_t w, int maximize) {
         }
 }
 
+WEBVIEW_API void webview_set_minimized(webview_t w){
+  struct mshtml_webview* wv = (struct mshtml_webview*)w;
+  ShowWindow(wv->hwnd, SW_SHOWMINIMIZED);
+}
+
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a) {
   struct mshtml_webview* wv = (struct mshtml_webview*)w;

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1109,34 +1109,41 @@ WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen) {
 
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize) {
   struct mshtml_webview* wv = (struct mshtml_webview*)w;
-  if (wv->is_maximized == !!maximize) {
+  BOOL is_maximized = IsZoomed(wv->hwnd);
+  if (is_maximized == maximize) {
     return;
   }
-  if (wv->is_maximized == 0) {
-    wv->saved_style = GetWindowLong(wv->hwnd, GWL_STYLE);
-    wv->saved_ex_style = GetWindowLong(wv->hwnd, GWL_EXSTYLE);
+  if (!is_maximized) {
     GetWindowRect(wv->hwnd, &wv->saved_rect);
   }
-  wv->is_maximized = !!maximize;
   if (maximize) {
-            RECT r;
+    RECT r;
 
-            SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0);
-            SetWindowPos(wv->hwnd, NULL, r.left, r.top, r.right - r.left,
-                        r.bottom - r.top,
-                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-        } else {
-            SetWindowPos(wv->hwnd, NULL, wv->saved_rect.left,
-                        wv->saved_rect.top,
-                        wv->saved_rect.right - wv->saved_rect.left,
-                        wv->saved_rect.bottom - wv->saved_rect.top,
-                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
-        }
+    SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0);
+    
+    ShowWindow(wv->hwnd, SW_MAXIMIZE);
+    SetWindowPos(wv->hwnd, NULL, r.left, r.top, r.right - r.left,
+                r.bottom - r.top,
+                SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+  } else {
+    ShowWindow(wv->hwnd, SW_RESTORE);
+    SetWindowPos(wv->hwnd, NULL, wv->saved_rect.left,
+                wv->saved_rect.top,
+                wv->saved_rect.right - wv->saved_rect.left,
+                wv->saved_rect.bottom - wv->saved_rect.top,
+                SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+  }
 }
 
-WEBVIEW_API void webview_set_minimized(webview_t w){
+WEBVIEW_API void webview_set_minimized(webview_t w, int minimize){
   struct mshtml_webview* wv = (struct mshtml_webview*)w;
-  ShowWindow(wv->hwnd, SW_SHOWMINIMIZED);
+  BOOL is_minimized = IsIconic(wv->hwnd);
+  if (is_minimized == minimize)
+      return;
+  if (minimize)
+      ShowWindow(wv->hwnd, SW_MINIMIZE);
+  else
+      ShowWindow(wv->hwnd, SW_RESTORE);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,


### PR DESCRIPTION
part of #199 

This should allow the one to call webview.set_minimized(), to set the window state to minimized.

The window can then be restored by normal means.