### PR TITLE
Implement draggeable frameless window (edge only)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,6 +445,10 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_minimized(self.inner.unwrap()) };
     }
 
+    pub fn drag_intent(&mut self) {
+        unsafe { webview_drag_intent(self.inner.unwrap()) };
+    }
+
     /// Returns a builder for opening a new dialog window.
     #[deprecated(
         note = "Please use crates like 'tinyfiledialogs' for dialog handling, see example in examples/dialog.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,14 +437,17 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_fullscreen(self.inner.unwrap(), fullscreen as _) };
     }
 
+    /// Enables or disables maximized state.
     pub fn set_maximized(&mut self, maximize: bool) {
         unsafe { webview_set_maximized(self.inner.unwrap(), maximize as _) };
     }
     
+    /// Enables or disables minimized state.
     pub fn set_minimized(&mut self) {
         unsafe { webview_set_minimized(self.inner.unwrap()) };
     }
 
+    /// Adds drag intent on function call, persists until mouse_up recieved.
     pub fn drag_intent(&mut self) {
         unsafe { webview_drag_intent(self.inner.unwrap()) };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,10 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_fullscreen(self.inner.unwrap(), fullscreen as _) };
     }
 
+    pub fn set_maximized(&mut self, maximize: bool) {
+        unsafe { webview_set_maximized(self.inner.unwrap(), maximize as _) };
+    }
+
     /// Returns a builder for opening a new dialog window.
     #[deprecated(
         note = "Please use crates like 'tinyfiledialogs' for dialog handling, see example in examples/dialog.rs"

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -49,6 +49,14 @@ unsafe extern "C" fn webview_set_fullscreen(webview: *mut WebView, fullscreen: c
     }
 }
 
+unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_int) {
+    if maximize > 0 {
+        gtk_window_maximize(mem::transmute((*webview).window));
+    } else {
+        gtk_window_unmaximize(mem::transmute((*webview).window));
+    }
+}
+
 #[no_mangle]
 unsafe extern "C" fn webview_new(
     title: *const c_char,

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -37,5 +37,6 @@ extern "C" {
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
     pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
     pub fn webview_set_minimized(this: *mut CWebView);
+    pub fn webview_drag_intent(this: *mut CWebView);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -35,5 +35,6 @@ extern "C" {
     pub fn webview_eval(this: *mut CWebView, js: *const c_char) -> c_int;
     pub fn webview_set_title(this: *mut CWebView, title: *const c_char);
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
+    pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -25,6 +25,7 @@ WEBVIEW_API int webview_loop(webview_t w, int blocking);
 WEBVIEW_API int webview_eval(webview_t w, const char *js);
 WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
+WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -27,6 +27,7 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
 WEBVIEW_API void webview_set_minimized(webview_t w);
+WEBVIEW_API void webview_drag_intent(webview_t w);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -289,15 +289,9 @@ public:
         }
         this->is_maximized = !!maximize;
         if (maximize) {
-            MONITORINFO monitor_info;
-            monitor_info.cbSize = sizeof(monitor_info);
-            GetMonitorInfo(MonitorFromWindow(this->m_window, MONITOR_DEFAULTTONEAREST),
-                        &monitor_info);
             RECT r;
-            r.left = monitor_info.rcMonitor.left;
-            r.top = monitor_info.rcMonitor.top;
-            r.right = monitor_info.rcMonitor.right;
-            r.bottom = monitor_info.rcMonitor.bottom;
+
+            SystemParametersInfoW(SPI_GETWORKAREA, 0, &r, 0);
             SetWindowPos(this->m_window, NULL, r.left, r.top, r.right - r.left,
                         r.bottom - r.top,
                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -278,6 +278,38 @@ public:
         }
     }
 
+    void set_maximized(bool maximize)
+    {
+
+        if (this->is_maximized == maximize) {
+            return;
+        }
+        if (!this->is_maximized) {
+            GetWindowRect(this->m_window, &this->saved_rect);
+        }
+        this->is_maximized = !!maximize;
+        if (maximize) {
+            MONITORINFO monitor_info;
+            monitor_info.cbSize = sizeof(monitor_info);
+            GetMonitorInfo(MonitorFromWindow(this->m_window, MONITOR_DEFAULTTONEAREST),
+                        &monitor_info);
+            RECT r;
+            r.left = monitor_info.rcMonitor.left;
+            r.top = monitor_info.rcMonitor.top;
+            r.right = monitor_info.rcMonitor.right;
+            r.bottom = monitor_info.rcMonitor.bottom;
+            SetWindowPos(this->m_window, NULL, r.left, r.top, r.right - r.left,
+                        r.bottom - r.top,
+                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        } else {
+            SetWindowPos(this->m_window, NULL, this->saved_rect.left,
+                        this->saved_rect.top,
+                        this->saved_rect.right - this->saved_rect.left,
+                        this->saved_rect.bottom - this->saved_rect.top,
+                        SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+        }
+    }
+
     void set_color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
     {
 
@@ -292,6 +324,7 @@ public:
     msg_cb_t m_cb;
 
     bool is_fullscreen = false;
+    bool is_maximized = false;
     DWORD saved_style = 0;
     DWORD saved_ex_style = 0;
     RECT saved_rect;
@@ -457,6 +490,11 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title)
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen)
 {
     static_cast<webview::webview*>(w)->set_fullscreen(fullscreen);
+}
+
+WEBVIEW_API void webview_set_maximized(webview_t w, int maximize)
+{
+    static_cast<webview::webview*>(w)->set_maximized(maximize);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,


### PR DESCRIPTION
This implements a method that one can call at mouse down on an area to start window drag.

kind of like 
document.getElementById('titlebar').addEventListener('mousedown', e => { external.invoke("window-drag")) }

"window-drag" => {
webview.drag_intent();
},

The feature moves window to mouse pos, I wanted to implement a more streamlined approach, by 
targetting WM_NCHITTEST msg under windowproc to return, HTCAPTION, but I didnt have any luck with that.

A similar feature can be implemented on gtk by using gtk_window_set_position, I dont have access to linux right now to build and test but can certainly helpout. 