### PR TITLE
Changed step to run unblocking, which effects how the UI responds to …

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,7 +458,7 @@ impl<'a, T> WebView<'a, T> {
     /// Iterates the event loop. Returns `None` if the view has been closed or terminated.
     pub fn step(&mut self) -> Option<WVResult> {
         unsafe {
-            match webview_loop(self.inner.unwrap(), 1) {
+            match webview_loop(self.inner.unwrap(), 0) {
                 0 => {
                     let closure_result = &mut self.user_data_wrapper_mut().result;
                     match closure_result {


### PR DESCRIPTION
This change changes the step function to be non-blocking. Without it seems not possible to implement a main loop with step that enables fine grain responsiveness, which causes issues when trying to process incoming real-time data streams.