### PR TITLE
Window visibility control.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,6 +110,7 @@ pub struct WebViewBuilder<'a, T: 'a, I, C> {
     pub invoke_handler: Option<I>,
     pub user_data: Option<T>,
     pub frameless: bool,
+    pub visible: bool,
 }
 
 impl<'a, T: 'a, I, C> Default for WebViewBuilder<'a, T, I, C>
@@ -133,6 +134,7 @@ where
             invoke_handler: None,
             user_data: None,
             frameless: false,
+            visible: true,
         }
     }
 }
@@ -195,6 +197,14 @@ where
         self
     }
 
+    /// Set the visibility of the WebView window.
+    ///
+    /// defaults to `true`
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.visible = visible;
+        self
+    }
+
     /// Sets the invoke handler callback. This will be called when a message is received from
     /// JavaScript.
     ///
@@ -243,6 +253,7 @@ where
             self.resizable,
             self.debug,
             self.frameless,
+            self.visible,
             user_data,
             invoke_handler,
         )
@@ -298,6 +309,7 @@ impl<'a, T> WebView<'a, T> {
         resizable: bool,
         debug: bool,
         frameless: bool,
+        visible: bool,
         user_data: T,
         invoke_handler: I,
     ) -> WVResult<WebView<'a, T>>
@@ -321,6 +333,7 @@ impl<'a, T> WebView<'a, T> {
                 resizable as _,
                 debug as _,
                 frameless as _,
+                visible as _,
                 Some(ffi_invoke_handler::<T>),
                 user_data_ptr as _,
             );
@@ -445,6 +458,11 @@ impl<'a, T> WebView<'a, T> {
     /// Minimizes window
     pub fn set_minimized(&mut self, minimize: bool) {
         unsafe { webview_set_minimized(self.inner.unwrap(), minimize as _) };
+    }
+
+    /// Set window visibility.
+    pub fn set_visible(&mut self, visible: bool) {
+        unsafe { webview_set_visible(self.inner.unwrap(), visible as _) };
     }
 
     /// Returns a builder for opening a new dialog window.

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -23,6 +23,7 @@ struct WebView {
     resizable: c_int,
     debug: c_int,
     frameless: c_int,
+    visible: c_int,
     external_invoke_cb: ExternalInvokeCallback,
     window: *mut GtkWidget,
     scroller: *mut GtkWidget,
@@ -49,6 +50,7 @@ unsafe extern "C" fn webview_set_fullscreen(webview: *mut WebView, fullscreen: c
     }
 }
 
+#[no_mangle]
 unsafe extern "C" fn webview_set_maximized(webview: *mut WebView, maximize: c_int) {
     if maximize == gtk_window_is_maximized(mem::transmute((*webview).window)) {
         return;
@@ -73,6 +75,15 @@ unsafe extern "C" fn webview_set_minimized(webview: *mut WebView, minimize: c_in
 }
 
 #[no_mangle]
+unsafe extern "C" fn webview_set_visible(webview: *mut WebView, visible: c_int) {
+    if visible != 0 {
+        gtk_widget_show_all(mem::transmute((*webview).window));
+    } else {
+        gtk_widget_hide(mem::transmute((*webview).window));
+    }
+}
+
+#[no_mangle]
 unsafe extern "C" fn webview_new(
     title: *const c_char,
     url: *const c_char,
@@ -81,6 +92,7 @@ unsafe extern "C" fn webview_new(
     resizable: c_int,
     debug: c_int,
     frameless: c_int,
+    visible: c_int,
     external_invoke_cb: ExternalInvokeCallback,
     userdata: *mut c_void,
 ) -> *mut WebView {
@@ -92,6 +104,7 @@ unsafe extern "C" fn webview_new(
         resizable,
         debug,
         frameless,
+        visible,
         external_invoke_cb,
         window: ptr::null_mut(),
         scroller: ptr::null_mut(),
@@ -186,7 +199,9 @@ unsafe extern "C" fn webview_new(
         );
     }
 
-    gtk_widget_show_all(window);
+    if visible != 0 {
+        gtk_widget_show_all(window);
+    }
 
     webkit_web_view_run_javascript(
             mem::transmute(webview),

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -25,6 +25,7 @@ extern "C" {
         resizable: c_int,
         debug: c_int,
         frameless: c_int,
+        visible: c_int,
         external_invoke_cb: Option<ErasedExternalInvokeFn>,
         userdata: *mut c_void,
     ) -> *mut CWebView;
@@ -37,5 +38,6 @@ extern "C" {
     pub fn webview_set_fullscreen(this: *mut CWebView, fullscreen: c_int);
     pub fn webview_set_maximized(this: *mut CWebView, maximize: c_int);
     pub fn webview_set_minimized(this: *mut CWebView, minimize: c_int);
+    pub fn webview_set_visible(this: *mut CWebView, visible: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
 }

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -27,6 +27,7 @@ WEBVIEW_API void webview_set_title(webview_t w, const char *title);
 WEBVIEW_API void webview_set_fullscreen(webview_t w, int fullscreen);
 WEBVIEW_API void webview_set_maximized(webview_t w, int maximize);
 WEBVIEW_API void webview_set_minimized(webview_t w, int minimize);
+WEBVIEW_API void webview_set_visible(webview_t w, int minimize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
@@ -36,7 +37,7 @@ WEBVIEW_API void webview_debug(const char *format, ...);
 WEBVIEW_API void webview_print_log(const char *s);
 
 WEBVIEW_API void* webview_get_user_data(webview_t w);
-WEBVIEW_API webview_t webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, int frameless, webview_external_invoke_cb_t external_invoke_cb, void* userdata);
+WEBVIEW_API webview_t webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, int frameless, int visible, webview_external_invoke_cb_t external_invoke_cb, void* userdata);
 WEBVIEW_API void webview_free(webview_t w);
 WEBVIEW_API void webview_destroy(webview_t w);
 

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -20,6 +20,7 @@ struct cocoa_webview {
   int resizable;
   int debug;
   int frameless;
+  int visible;
   webview_external_invoke_cb_t external_invoke_cb;
   struct webview_priv priv;
   void *userdata;
@@ -46,6 +47,7 @@ WEBVIEW_API webview_t webview_new(
 	wv->resizable = resizable;
 	wv->debug = debug;
   wv->frameless = frameless;
+  wv->visible = visible;
 	wv->external_invoke_cb = external_invoke_cb;
 	wv->userdata = userdata;
 	if (webview_init(wv) != 0) {
@@ -448,7 +450,10 @@ WEBVIEW_API int webview_init(webview_t w) {
                (NSViewWidthSizable | NSViewHeightSizable));
   objc_msgSend(objc_msgSend(wv->priv.window, sel_registerName("contentView")),
                sel_registerName("addSubview:"), wv->priv.webview);
-  objc_msgSend(wv->priv.window, sel_registerName("orderFrontRegardless"));
+
+  if (wv->visible) {
+    objc_msgSend(wv->priv.window, sel_registerName("orderFrontRegardless"));
+  }
 
   objc_msgSend(objc_msgSend((id)objc_getClass("NSApplication"),
                             sel_registerName("sharedApplication")),
@@ -594,6 +599,16 @@ WEBVIEW_API void webview_set_minimized(webview_t w, int minimize) {
     objc_msgSend(wv->priv.window, sel_registerName("deminiaturize:"), NULL);
   }
   
+}
+
+WEBVIEW_API void webview_set_visible(webview_t w, int visible) {
+  struct cocoa_webview* wv = (struct cocoa_webview*)w;
+
+  if (visible) {
+    objc_msgSend(wv->priv.window, sel_registerName("orderFrontRegardless"));
+  } else {
+    objc_msgSend(wv->priv.window, sel_registerName("orderOut"));
+  }
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -36,7 +36,7 @@ WEBVIEW_API void* webview_get_user_data(webview_t w) {
 
 WEBVIEW_API webview_t webview_new(
   const char* title, const char* url, 
-  int width, int height, int resizable, int debug, int frameless,
+  int width, int height, int resizable, int debug, int frameless, int visible,
   webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 	struct cocoa_webview* wv = (struct cocoa_webview*)calloc(1, sizeof(*wv));
 	wv->width = width;

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -97,7 +97,7 @@ static const TCHAR *classname = "WebView";
 
 WEBVIEW_API webview_t webview_new(
   const char* title, const char* url, int width, int height, int resizable, int debug, 
-  int frameless, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
+  int frameless, int visible, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 
   if (webview_fix_ie_compat_mode() < 0) {
     return NULL;

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -195,7 +195,7 @@ WEBVIEW_API webview_t webview_new(
 
   DisplayHTMLPage(wv);
 
-  ShowWindow(wv->hwnd, SW_SHOWDEFAULT);
+  ShowWindow(wv->hwnd, visible ? SW_SHOWDEFAULT : SW_HIDE);
   UpdateWindow(wv->hwnd);
   SetFocus(wv->hwnd);
 
@@ -1144,6 +1144,12 @@ WEBVIEW_API void webview_set_minimized(webview_t w, int minimize){
       ShowWindow(wv->hwnd, SW_MINIMIZE);
   else
       ShowWindow(wv->hwnd, SW_RESTORE);
+}
+
+WEBVIEW_API void webview_set_visible(webview_t w, int visible) {
+  struct mshtml_webview* wv = (struct mshtml_webview*)w;
+
+  ShowWindow(wv->hwnd, visible ? SW_SHOW : SW_HIDE);
 }
 
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,


### PR DESCRIPTION
Added a way to show or hide the window. I've tested in Edge, MSHTML, Cocoa, GTK and found no problems.

Having the ability to hide the window is useful in Edge because it has a white background when the window first appears, and `set_color()` has no effect. After the page load, I show the window, bypassing a horrible experience of seeing the page load.