### PR TITLE
Upgrade dependencies

### DIFF
--- a/webview-sys/Cargo.toml
+++ b/webview-sys/Cargo.toml
@@ -20,12 +20,12 @@ edge = []
 
 [target.'cfg(all(target_family = "unix", not(target_os = "macos")))'.dependencies]
 javascriptcore-rs-sys = "0.2"
-gtk-sys = "0.9"
-glib-sys = "0.9"
-gobject-sys = "0.9"
-webkit2gtk-sys = { version = "0.10", features = ["v2_8"] }
-gdk-sys = "0.9"
-gio-sys = "0.9"
+gtk-sys = "0.10"
+glib-sys = "0.10"
+gobject-sys = "0.10"
+webkit2gtk-sys = { version = "0.12.0", features = ["v2_8"] }
+gdk-sys = "0.10"
+gio-sys = "0.10"
 libc = "0.2"
 
 [build-dependencies]


### PR DESCRIPTION
Hello,
One of my projects needed `glib = "^0.10"` so I upgraded the dependencies of `webview-sys`, and here's a PR if that's of any use to you.
I tested all the examples and they work fine on my Ubuntu 20.04.
If there are other tests I can do to make sure I didn't break anything, please let me know!