### PR TITLE
Windows-EDGE frameless fixes

### DIFF
--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -147,6 +147,7 @@ public:
         SetWindowLongPtr(m_window, GWLP_USERDATA, (LONG_PTR)this);
         if (frameless)
         {
+            is_frameless = true;
             SetWindowLongPtr(m_window, GWL_STYLE, style);
             static const MARGINS shadow = {1, 1, 1, 1};
             DwmExtendFrameIntoClientArea(m_window, &shadow);
@@ -394,6 +395,7 @@ public:
 
     bool is_fullscreen = false;
     bool is_maximized = false;
+    bool is_frameless = false;
     DWORD saved_style = 0;
     DWORD saved_ex_style = 0;
     RECT saved_rect;
@@ -432,9 +434,14 @@ LRESULT CALLBACK WebviewWndProc(HWND hwnd, UINT msg, WPARAM wp, LPARAM lp)
         
         break;
     }
-    case WM_NCHITTEST:
-        return (*w).hit_test(POINT{LOWORD(lp), HIWORD(lp)}, hwnd);
+    case WM_NCHITTEST: {
+        if ((*w).is_frameless) {
+            return (*w).hit_test(POINT{LOWORD(lp), HIWORD(lp)}, hwnd);
+        } else {
+            return DefWindowProc(hwnd, msg, wp, lp);
+        }
         break;
+    }
     default:
         return DefWindowProc(hwnd, msg, wp, lp);
     }


### PR DESCRIPTION
This implements a border less frame, Currently I have a 2px margin for resizing and can implement a method to set the same. I have no idea how Mshtml implementation works now, the code is getting hard to understand...

I can create a seperate PR to also implement the DRAG_WINDOW method I use on https://github.com/Blakeinstein/Bloop along with cross-platform implements. I dont have testing platform for linux and macos anymore. So if anyone can tell me how frameless looks on the same, I will look into it aswell.

I have started this PR as a discussion platform first.