### PR TITLE
Added two useful method "set_html" and "set_zoom_level" 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web-view"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Boscop", "zxey <r.hozak@seznam.cz>", "Sam Green <sam.green81@gmail.com>"]
 readme = "README.md"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,6 +451,24 @@ impl<'a, T> WebView<'a, T> {
         unsafe { webview_set_color(self.inner.unwrap(), color.r, color.g, color.b, color.a) }
     }
 
+    /// Sets the page native browser zoom level.
+    pub fn set_zoom_level(&mut self, percentage: f32) {
+        unsafe { webview_set_zoom_level(self.inner.unwrap(), percentage) }
+    }
+
+    /// Sets the page HTML directly.
+    ///
+    /// # Errors
+    ///
+    /// If `html` contain a nul byte, returns [`Error::NulByte`].
+    ///
+    /// [`Error::NulByte`]: enum.Error.html#variant.NulByte
+    pub fn set_html(&mut self, html: &str) -> WVResult {
+        let html = CString::new(html)?;
+        unsafe { webview_set_html(self.inner.unwrap(), html.as_ptr()) }
+        Ok(())
+    }
+
     /// Sets the title displayed at the top of the window.
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,7 @@ impl<'a, T> WebView<'a, T> {
     }
 
     /// Sets the page native browser zoom level.
-    pub fn set_zoom_level(&mut self, percentage: f32) {
+    pub fn set_zoom_level(&mut self, percentage: f64) {
         unsafe { webview_set_zoom_level(self.inner.unwrap(), percentage) }
     }
 

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -304,6 +304,16 @@ unsafe extern "C" fn webview_set_color(webview: *mut WebView, r: u8, g: u8, b: u
     webkit_web_view_set_background_color(mem::transmute((*webview).webview), &color);
 }
 
+#[no_mangle]
+unsafe extern "C" fn webview_set_zoom_level(webview: *mut WebView, percentage: c_double) {
+    webkit_web_view_set_zoom_level(mem::transmute((*webview).webview), percentage);
+}
+
+#[no_mangle]
+unsafe extern "C" fn webview_set_html(webview: *mut WebView, html: *const c_char) {
+    webkit_web_view_load_html(mem::transmute((*webview).webview), html, CStr::from_bytes_with_nul_unchecked(b"").as_ptr());
+}
+
 unsafe extern "C" fn webview_load_changed_cb(
     _webview: *mut WebKitWebView,
     event: WebKitLoadEvent,

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -232,12 +232,12 @@ unsafe extern "C" fn webview_new(
     }
 
     webkit_web_view_run_javascript(
-            mem::transmute(webview),
-            CStr::from_bytes_with_nul_unchecked(b"window.external={invoke:function(x){window.webkit.messageHandlers.external.postMessage(x);}}\0").as_ptr(),
-            ptr::null_mut(),
-            None,
-            ptr::null_mut(),
-        );
+        mem::transmute(webview),
+        CStr::from_bytes_with_nul_unchecked(b"window.external={invoke:function(x){window.webkit.messageHandlers.external.postMessage(x);}}\0").as_ptr(),
+        ptr::null_mut(),
+        None,
+        ptr::null_mut(),
+    );
 
     g_signal_connect_data(
         mem::transmute(window),
@@ -311,7 +311,11 @@ unsafe extern "C" fn webview_set_zoom_level(webview: *mut WebView, percentage: c
 
 #[no_mangle]
 unsafe extern "C" fn webview_set_html(webview: *mut WebView, html: *const c_char) {
-    webkit_web_view_load_html(mem::transmute((*webview).webview), html, CStr::from_bytes_with_nul_unchecked(b"").as_ptr());
+    webkit_web_view_load_html(
+        mem::transmute((*webview).webview),
+        html,
+        CStr::from_bytes_with_nul_unchecked(b"").as_ptr(),
+    );
 }
 
 unsafe extern "C" fn webview_load_changed_cb(

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -42,6 +42,6 @@ extern "C" {
     pub fn webview_set_minimized(this: *mut CWebView, minimize: c_int);
     pub fn webview_set_visible(this: *mut CWebView, visible: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
-    pub fn webview_set_zoom_level(this: *mut CWebView, percentage: c_float);
+    pub fn webview_set_zoom_level(this: *mut CWebView, percentage: c_double);
     pub fn webview_set_html(this: *mut CWebView, html: *const c_char);
 }

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -42,4 +42,6 @@ extern "C" {
     pub fn webview_set_minimized(this: *mut CWebView, minimize: c_int);
     pub fn webview_set_visible(this: *mut CWebView, visible: c_int);
     pub fn webview_set_color(this: *mut CWebView, red: u8, green: u8, blue: u8, alpha: u8);
+    pub fn webview_set_zoom_level(this: *mut CWebView, percentage: c_float);
+    pub fn webview_set_html(this: *mut CWebView, html: *const c_char);
 }

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -30,7 +30,7 @@ WEBVIEW_API void webview_set_minimized(webview_t w, int minimize);
 WEBVIEW_API void webview_set_visible(webview_t w, int minimize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
-WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage);
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const double percentage);
 WEBVIEW_API void webview_set_html(webview_t w, const char *html);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
                                   void *arg);

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -30,6 +30,8 @@ WEBVIEW_API void webview_set_minimized(webview_t w, int minimize);
 WEBVIEW_API void webview_set_visible(webview_t w, int minimize);
 WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a);
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage);
+WEBVIEW_API void webview_set_html(webview_t w, const char *html);
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,
                                   void *arg);
 WEBVIEW_API void webview_exit(webview_t w);

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -644,7 +644,7 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                sel_registerName("setTitlebarAppearsTransparent:"), 1);
 }
 
-WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const double percentage) {
     // Ignored on Cocoa
 }
 

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -643,6 +643,17 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
   objc_msgSend(wv->priv.window,
                sel_registerName("setTitlebarAppearsTransparent:"), 1);
 }
+
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+    // Ignored on Cocoa
+}
+
+WEBVIEW_API void webview_set_html(webview_t w, const char *html) {
+    struct cocoa_webview* wv = (struct cocoa_webview*)w;
+    objc_msgSend(wv->priv.window, sel_registerName("loadHTMLString:"),
+                 get_nsstring(html));
+}
+
 static void webview_dispatch_cb(void *arg) {
   struct webview_dispatch_arg *context = (struct webview_dispatch_arg *)arg;
   (context->fn)(context->w, context->arg);

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -277,6 +277,7 @@ public:
                         SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
         }
     }
+
     void set_minimized(bool minimize)
     {   
         bool is_minimized = IsIconic(this->m_window);
@@ -327,6 +328,11 @@ public:
 
         HBRUSH brush = CreateSolidBrush(RGB(r, g, b));
         SetClassLongPtr(this->m_window, GCLP_HBRBACKGROUND, (LONG_PTR)brush);
+    }
+
+    void set_html(const char* html)
+    {
+        m_webview.NavigateToString(winrt::to_hstring(html.c_str()));
     }
 
     int get_min_width() {
@@ -543,6 +549,14 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
                                    uint8_t b, uint8_t a)
 {
     static_cast<webview::webview*>(w)->set_color(r, g, b, a);
+}
+
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+    // Ignored on EdgeHTML
+}
+
+WEBVIEW_API void webview_set_html(webview_t w, const char *html) {
+    static_cast<webview::webview*>(w)->set_html(html);
 }
 
 WEBVIEW_API void webview_dispatch(webview_t w, webview_dispatch_fn fn,

--- a/webview-sys/webview_edge.cpp
+++ b/webview-sys/webview_edge.cpp
@@ -551,7 +551,7 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
     static_cast<webview::webview*>(w)->set_color(r, g, b, a);
 }
 
-WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const double percentage) {
     // Ignored on EdgeHTML
 }
 

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1174,14 +1174,23 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
 }
 
 WEBVIEW_API void webview_set_zoom_level(webview_t w, const double percentage) {
+    struct mshtml_webview* wv = (struct mshtml_webview*)w;
+
     int OLECMDID_OPTICAL_ZOOM = 63;
     int OLECMDEXECOPT_DONTPROMPTUSER = 2;
+
+    VARIANT vPercentage;
+
+    VariantInit(&vPercentage);
+
+    vPercentage.vt = VT_R8;
+    vPercentage.dblVal = percentage;
 
     IWebBrowser2 *webBrowser;
     IOleObject *browser = *wv->browser;
     if (browser->lpVtbl->QueryInterface(browser, iid_unref(&IID_IWebBrowser2),
                                         (void **)&webBrowser) == S_OK) {
-        webBrowser->lpVtbl->ExecWB(webBrowser, OLECMDID_OPTICAL_ZOOM, OLECMDEXECOPT_DONTPROMPTUSER, &percentage, percentage);
+        webBrowser->lpVtbl->ExecWB(webBrowser, OLECMDID_OPTICAL_ZOOM, OLECMDEXECOPT_DONTPROMPTUSER, &vPercentage, &vPercentage);
     }
 }
 

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1173,6 +1173,25 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
   SetClassLongPtr(wv->hwnd, GCLP_HBRBACKGROUND, (LONG_PTR)brush);
 }
 
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+    int OLECMDID_OPTICAL_ZOOM = 63;
+    int OLECMDEXECOPT_DONTPROMPTUSER = 2;
+
+    IWebBrowser2 *webBrowser;
+    IOleObject *browser = *wv->browser;
+    if (browser->lpVtbl->QueryInterface(browser, iid_unref(&IID_IWebBrowser2),
+                                        (void **)&webBrowser) == S_OK) {
+        webBrowser->lpVtbl->ExecWB(webBrowser, OLECMDID_OPTICAL_ZOOM, OLECMDEXECOPT_DONTPROMPTUSER, &percentage, percentage);
+    }
+}
+
+WEBVIEW_API void webview_set_html(webview_t w, const char *html) {
+    struct mshtml_webview* wv = (struct mshtml_webview*)w;
+    wv->url = html;
+
+    DisplayHTMLPage(wv);
+}
+
 WEBVIEW_API void webview_exit(webview_t w) {
   struct mshtml_webview* wv = (struct mshtml_webview*)w;
   DestroyWindow(wv->hwnd);

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -1173,7 +1173,7 @@ WEBVIEW_API void webview_set_color(webview_t w, uint8_t r, uint8_t g,
   SetClassLongPtr(wv->hwnd, GCLP_HBRBACKGROUND, (LONG_PTR)brush);
 }
 
-WEBVIEW_API void webview_set_zoom_level(webview_t w, const float percentage) {
+WEBVIEW_API void webview_set_zoom_level(webview_t w, const double percentage) {
     int OLECMDID_OPTICAL_ZOOM = 63;
     int OLECMDEXECOPT_DONTPROMPTUSER = 2;
 


### PR DESCRIPTION
As I already did in the original [webview](https://github.com/webview/webview/pull/482) project, two important method was missing from this library:
- `set_html(html_string)`
- `set_zoom_level(percent_of_zoom)`

The first let you to insert directly an HTML content, the second function let you to set a custom webkit renderer zoom level programmatically.