### PR TITLE
macOS: Allow graceful close with Cmd+Q

### DIFF
--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -519,7 +519,7 @@ WEBVIEW_API int webview_init(webview_t w) {
 
   title = objc_msgSend(get_nsstring("Quit "),
                        sel_registerName("stringByAppendingString:"), appName);
-  item = create_menu_item(title, "terminate:", "q");
+  item = create_menu_item(title, wv->frameless ? "terminate:" : "close", "q");
   objc_msgSend(appMenu, sel_registerName("addItem:"), item);
 
   objc_msgSend(objc_msgSend((id)objc_getClass("NSApplication"),


### PR DESCRIPTION
On macOS, pressing Cmd+Q or using the "Quit" menu item will terminate the application. In other words, `WebView::run()` never returns, preventing the application from performing any cleanup or other tasks (e.g. saving the user data).

This patch switches the "Quit" menu item to send the `close` message instead of `terminate:`. But only if there is a close button on the window. The `terminate:` message will still be used on frameless windows. (I haven't found a way to gracefully close them without terminating the app.)

Using the `close` message allows `WebView::run()` to return, and the application can continue running in the background or open a new window if it wants to.