### PR TITLE
GTK: close the window on WebView::exit() (fix for #206)

### DIFF
--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -292,6 +292,7 @@ unsafe extern "C" fn webview_loop(webview: *mut WebView, blocking: c_int) -> c_i
     gtk_main_iteration_do(blocking);
     if (*webview).should_exit != 0 {
         gtk_window_close((*webview).window as *mut GtkWindow);
+        gtk_main_iteration_do(0);
     }
     (*webview).should_exit
 }
@@ -413,7 +414,7 @@ unsafe extern "C" fn webview_destroy_cb(_widget: *mut GtkWidget, arg: gpointer) 
 #[no_mangle]
 unsafe extern "C" fn webview_exit(webview: *mut WebView) {
     (*webview).should_exit = 1;
-    webview_loop(webview, 0);
+    webview_loop(webview, 0); // pump the event loop to apply
 }
 
 #[no_mangle]

--- a/webview-sys/gtk.rs
+++ b/webview-sys/gtk.rs
@@ -290,6 +290,9 @@ unsafe extern "C" fn webview_free(webview: *mut WebView) {
 #[no_mangle]
 unsafe extern "C" fn webview_loop(webview: *mut WebView, blocking: c_int) -> c_int {
     gtk_main_iteration_do(blocking);
+    if (*webview).should_exit != 0 {
+        gtk_window_close((*webview).window as *mut GtkWindow);
+    }
     (*webview).should_exit
 }
 
@@ -410,6 +413,7 @@ unsafe extern "C" fn webview_destroy_cb(_widget: *mut GtkWidget, arg: gpointer) 
 #[no_mangle]
 unsafe extern "C" fn webview_exit(webview: *mut WebView) {
     (*webview).should_exit = 1;
+    webview_loop(webview, 0);
 }
 
 #[no_mangle]


### PR DESCRIPTION
With the latest `master`, I can reproduce issue #206 ([original example](https://github.com/kellpossible/web-view-test/tree/2a939c84ac5c2f0ed32fd43b50cb0f1714b159af) and [my take on it](https://github.com/zec/webview-minimal-reproductions/tree/5d99c7f24b99ada5522cf8b6b2d24e8faea5a683/issue206)): when using the GTK/WebKit binding, calling WebView::exit() does not actually close the `web-view`-generated window. This PR fixes that by ensuring the GtkWindow is closed upon a call to exit().