### PR TITLE
Exclude Cargo.lock from crates uploaded to, e.g., crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Boscop/web-view"
 description = "Rust bindings for webview, a tiny cross-platform library to render web-based GUIs for desktop applications"
 keywords = ["web", "gui", "desktop", "electron", "webkit"]
 categories = ["gui", "web-programming", "api-bindings", "rendering", "visualization"]
-exclude = ["examples/todo-ps/dist/**/*", "examples/elm-counter/index.html"]
+exclude = ["examples/todo-ps/dist/**/*", "examples/elm-counter/index.html", "Cargo.lock"]
 
 [dependencies]
 urlencoding = "1.1"

--- a/webview-sys/Cargo.toml
+++ b/webview-sys/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["gui", "web-programming", "api-bindings", "rendering", "visualizat
 build = "build.rs"
 links = "webview"
 edition = "2018"
+exclude = ["Cargo.lock"]
 
 [lib]
 name = "webview_sys"


### PR DESCRIPTION
It appears that sometimes the contents of the `Cargo.lock` file in uploaded `web-view` crates cause Rustdoc compilation to fail. As libraries generally shouldn't have `Cargo.lock` files except for local development [[1]](https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries), this adds `Cargo.lock` to the file excludes in `Cargo.toml`.

This should fix issue #257.