### PR TITLE
Hide window instead of closing.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub struct WebViewBuilder<'a, T: 'a, I, C> {
     pub visible: bool,
     pub min_width: i32,
     pub min_height: i32,
+    pub hide_instead_of_close: bool,
 }
 
 impl<'a, T: 'a, I, C> Default for WebViewBuilder<'a, T, I, C>
@@ -139,6 +140,7 @@ where
             visible: true,
             min_width: 300,
             min_height: 300,
+            hide_instead_of_close: false,
         }
     }
 }
@@ -218,6 +220,14 @@ where
         self
     }
 
+    /// Sets behavior of the window when closed.
+    ///
+    /// default to `false`
+    pub fn hide_instead_of_close(mut self, value: bool) -> Self {
+        self.hide_instead_of_close = value;
+        self
+    }
+
     /// Sets the invoke handler callback. This will be called when a message is received from
     /// JavaScript.
     ///
@@ -269,6 +279,7 @@ where
             self.visible,
             self.min_width,
             self.min_height,
+            self.hide_instead_of_close,
             user_data,
             invoke_handler,
         )
@@ -327,6 +338,7 @@ impl<'a, T> WebView<'a, T> {
         visible: bool,
         min_width: i32,
         min_height: i32,
+        hide_instead_of_close: bool,
         user_data: T,
         invoke_handler: I,
     ) -> WVResult<WebView<'a, T>>
@@ -353,6 +365,7 @@ impl<'a, T> WebView<'a, T> {
                 visible as _,
                 min_width,
                 min_height,
+                hide_instead_of_close as _,
                 Some(ffi_invoke_handler::<T>),
                 user_data_ptr as _,
             );

--- a/webview-sys/lib.rs
+++ b/webview-sys/lib.rs
@@ -28,6 +28,7 @@ extern "C" {
         visible: c_int,
         min_width: c_int,
         min_height: c_int,
+        hide_instead_of_close: c_int,
         external_invoke_cb: Option<ErasedExternalInvokeFn>,
         userdata: *mut c_void,
     ) -> *mut CWebView;

--- a/webview-sys/webview.h
+++ b/webview-sys/webview.h
@@ -40,7 +40,7 @@ WEBVIEW_API void webview_print_log(const char *s);
 
 WEBVIEW_API void* webview_get_user_data(webview_t w);
 WEBVIEW_API void* webview_get_window_handle(webview_t w);
-WEBVIEW_API webview_t webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, int frameless, int visible, int min_width, int min_height, webview_external_invoke_cb_t external_invoke_cb, void* userdata);
+WEBVIEW_API webview_t webview_new(const char* title, const char* url, int width, int height, int resizable, int debug, int frameless, int visible, int min_width, int min_height, int hide_instead_of_close, webview_external_invoke_cb_t external_invoke_cb, void* userdata);
 WEBVIEW_API void webview_free(webview_t w);
 WEBVIEW_API void webview_destroy(webview_t w);
 

--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -23,6 +23,7 @@ struct cocoa_webview {
   int visible;
   int min_width;
   int min_height;
+  int hide_instead_of_close;
   webview_external_invoke_cb_t external_invoke_cb;
   struct webview_priv priv;
   void *userdata;
@@ -39,7 +40,7 @@ WEBVIEW_API void* webview_get_user_data(webview_t w) {
 
 WEBVIEW_API webview_t webview_new(
   const char* title, const char* url, 
-  int width, int height, int resizable, int debug, int frameless, int visible, int min_width, int min_height,
+  int width, int height, int resizable, int debug, int frameless, int visible, int min_width, int min_height, int hide_instead_of_close,
   webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 	struct cocoa_webview* wv = (struct cocoa_webview*)calloc(1, sizeof(*wv));
 	wv->width = width;
@@ -52,6 +53,7 @@ WEBVIEW_API webview_t webview_new(
   wv->visible = visible;
   wv->min_width = min_width;
   wv->min_height = min_height;
+  wv->hide_instead_of_close = hide_instead_of_close;
 	wv->external_invoke_cb = external_invoke_cb;
 	wv->userdata = userdata;
 	if (webview_init(wv) != 0) {
@@ -134,6 +136,19 @@ static void webview_window_will_close(id self, SEL cmd, id notification) {
   objc_msgSend(app, sel_registerName("postEvent:atStart:"), event, 
                     objc_msgSend((id)objc_getClass("NSDate"),
                       sel_registerName("distantPast")));
+}
+
+static bool webview_window_should_close(id self, SEL cmd, id sender) {
+  struct cocoa_webview *wv =
+      (struct cocoa_webview *)objc_getAssociatedObject(self, "webview");
+
+  if (wv->hide_instead_of_close) {
+    webview_set_visible(wv, 0);
+
+    return false;
+  } else {
+    return true;
+  }
 }
 
 static void webview_external_invoke(id self, SEL cmd, id contentController,
@@ -361,6 +376,8 @@ WEBVIEW_API int webview_init(webview_t w) {
     class_addProtocol(__NSWindowDelegate, objc_getProtocol("NSWindowDelegate"));
     class_replaceMethod(__NSWindowDelegate, sel_registerName("windowWillClose:"),
                         (IMP)webview_window_will_close, "v@:@");
+    class_replaceMethod(__NSWindowDelegate, sel_registerName("windowShouldClose:"),
+                        (IMP)webview_window_should_close, "B@:@");
     objc_registerClassPair(__NSWindowDelegate);
   }
 

--- a/webview-sys/webview_mshtml.c
+++ b/webview-sys/webview_mshtml.c
@@ -33,6 +33,7 @@ struct mshtml_webview {
   int frameless;
   int min_width;
   int min_height;
+  int hide_instead_of_close;
   webview_external_invoke_cb_t external_invoke_cb;
   void *userdata;
   HWND hwnd;
@@ -104,7 +105,7 @@ static const TCHAR *classname = "WebView";
 
 WEBVIEW_API webview_t webview_new(
   const char* title, const char* url, int width, int height, int resizable, int debug,
-  int frameless, int visible, int min_width, int min_height, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
+  int frameless, int visible, int min_width, int min_height, int hide_instead_of_close, webview_external_invoke_cb_t external_invoke_cb, void* userdata) {
 
   if (webview_fix_ie_compat_mode() < 0) {
     return NULL;
@@ -182,6 +183,7 @@ WEBVIEW_API webview_t webview_new(
   wv->frameless = frameless;
   wv->min_width = min_width;
   wv->min_height = min_height;
+  wv->hide_instead_of_close = hide_instead_of_close;
   wv->external_invoke_cb = external_invoke_cb;
   wv->userdata = userdata;
   wv->hwnd =
@@ -962,7 +964,16 @@ LRESULT CALLBACK wndproc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 
     break;
   }
+  case WM_CLOSE:
+    if (wv->hide_instead_of_close) {
+      ShowWindow(hwnd, SW_HIDE);
+    } else {
+      DestroyWindow(hwnd);
+    }
+
+    return TRUE;
   }
+  
   return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 


### PR DESCRIPTION
This new feature allows the user to hide the window instead of closing it. Later, the user can call `set_visible(true)` to restore the window.

To use this feature, the user must call `hide_instead_of_close(true)` when building the `WebView` object.

This feature works well in applications with a tray bar icon. The user can later restore the window by clicking on the application icon, bypassing all the loading necessary to restore the interface otherwise.