### PR TITLE
Remove Tauri From Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ For more usage info please check out the [examples](https://github.com/Boscop/we
 - [Compactor](https://github.com/Freaky/Compactor) - Windows 10 filesystem compression utility
 - [neutrino](https://github.com/alexislozano/neutrino/) - A GUI frontend in Rust based on web-view
 - [SOUNDSENSE-RS](https://github.com/prixt/soundsense-rs) - Sound-engine tool for Dwarf Fortress
-- [Tauri](https://github.com/tauri-apps/tauri) - Bringing security into webstack GUIs, with strong support for your favorite JS frameworks
 - [WV Linewise](https://github.com/forbesmyester/wv-linewise) - Add your own interactive HTML/CSS/JS in the middle of your UNIX pipelines
 - [Bloop](https://github.com/Blakeinstein/Bloop) - A light weight aesthetic scratchpad for developers.
 


### PR DESCRIPTION
Tauri now consumes its very own windowing crate [TAO](https://github.com/tauri-apps/tao) and a 100% based rust webview crate [WRY](https://github.com/tauri-apps/wry). Very soon we will support iOS, pureOS, and Android - and we are very close to having a webdriver.io compliant tauri-driver for running e2e tests in the webview.

However, we are primarily removing ourselves from this list because there is a wild rumor circulating that Tauri requires MSHTML, and this is absolutely no longer true.