### PR TITLE
[cocoa] Fix uninitialized webview_init error

### DIFF
--- a/webview-sys/webview_cocoa.c
+++ b/webview-sys/webview_cocoa.c
@@ -29,6 +29,8 @@ struct cocoa_webview {
   void *userdata;
 };
 
+WEBVIEW_API int webview_init(webview_t w);
+
 WEBVIEW_API void webview_free(webview_t w) {
 	free(w);
 }


### PR DESCRIPTION
I'm not entirely sure what caused this, but I assume it must be a newer C compiler on my end due to an Xcode update or something. `web-view` failed to compile with this error:

```
  running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-g" "-fno-omit-frame-pointer" "-arch" "arm64" "-I" "webview.h" "-Wall" "-Wextra" "-x" "objective-c" "-std=c11" "-w" "-DDEBUG" "-o" "/Users/realpassy/fbsource/xplat/sonar/facebook/flipper-launcher/target/debug/build/webview-sys-92f7fba9394d5e99/out/webview_cocoa.o" "-c" "webview_cocoa.c"
  cargo:warning=webview_cocoa.c:59:6: error: call to undeclared function 'webview_init'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cargo:warning=        if (webview_init(wv) != 0) {
  cargo:warning=            ^
  cargo:warning=webview_cocoa.c:59:6: note: did you mean 'webview_exit'?
  cargo:warning=./webview.h:37:18: note: 'webview_exit' declared here
  cargo:warning=WEBVIEW_API void webview_exit(webview_t w);
  cargo:warning=                 ^
  cargo:warning=1 error generated.
  exit status: 1
```

Adding a stand-alone declaration to the top fixes it.