### PR TITLE
[webview-sys] Update for XCode 15.3

### DIFF
--- a/webview-sys/build.rs
+++ b/webview-sys/build.rs
@@ -49,10 +49,7 @@ fn main() {
             }
         }
     } else if target.contains("apple") {
-        build
-            .file("webview_cocoa.c")
-            .flag("-x")
-            .flag("objective-c");
+        build.file("webview_cocoa.c").flag("-x").flag("objective-c");
         println!("cargo:rustc-link-lib=framework=Cocoa");
         println!("cargo:rustc-link-lib=framework=WebKit");
     } else {


### PR DESCRIPTION
Building against XCode 15.3 fails due to a bunch of hardened conversions to ID with output like this:

https://gist.github.com/passy/35f7a708d4c2751706cbd96e138c5390

This changes the types in the relevant signatures to match what we actually passed in.

Validated using the `minimal` example:

![image](https://github.com/Boscop/web-view/assets/9906/c760d135-f284-48be-a397-ab244cca553c)
